### PR TITLE
es: the Etre CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ vendor/
 tags
 coverage.out
 bin/etre/etre
+es/bin/bin

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,13 +12,22 @@
 			"Rev": "a3f95b5c423586578a4e099b11a46c2479628cac"
 		},
 		{
+			"ImportPath": "github.com/alexflint/go-arg",
+			"Rev": "cef6506c97e5731da728c374ff3523e481026423"
+		},
+		{
+			"ImportPath": "github.com/alexflint/go-scalar",
+			"Rev": "e80c3b7ed292b052c7083b6fd7154a8422c33f65"
+		},
+		{
 			"ImportPath": "github.com/dgrijalva/jwt-go",
 			"Comment": "v3.0.0-8-g24c63f5",
 			"Rev": "24c63f56522a87ec5339cc3567883f1039378fdb"
 		},
 		{
 			"ImportPath": "github.com/go-test/deep",
-			"Rev": "f49763a6ea0a91026be26f8213bebee726b4185f"
+			"Comment": "v1.0.0",
+			"Rev": "9898238679c264cfb10411539f14a0553dc8b295"
 		},
 		{
 			"ImportPath": "github.com/golang/glog",
@@ -30,8 +39,8 @@
 		},
 		{
 			"ImportPath": "github.com/gorilla/websocket",
-			"Comment": "v1.0.0-21-g2d1e454",
-			"Rev": "2d1e4548da234d9cb742cc3628556fef86aafbac"
+			"Comment": "v1.2.0-9-g4201258",
+			"Rev": "4201258b820c74ac8e6922fc9e6b52f71fe46f8d"
 		},
 		{
 			"ImportPath": "github.com/labstack/echo",
@@ -120,31 +129,32 @@
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
-			"Rev": "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "dc1f89aff9a7509782bde3b68824c8043a3e58cc"
-		},
-		{
-			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "dc1f89aff9a7509782bde3b68824c8043a3e58cc"
+			"Rev": "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "dc1f89aff9a7509782bde3b68824c8043a3e58cc"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
+		},
+		{
+			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "dc1f89aff9a7509782bde3b68824c8043a3e58cc"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "dc1f89aff9a7509782bde3b68824c8043a3e58cc"
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		},
 		{
-			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "dc1f89aff9a7509782bde3b68824c8043a3e58cc"
+			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
+			"Comment": "kubernetes-1.9.0-alpha.1-65-g18a564b",
+			"Rev": "18a564baac720819100827c16fdebcadb05b2d0d"
 		}
 	]
 }

--- a/api/api.go
+++ b/api/api.go
@@ -498,15 +498,15 @@ func writeOp(c echo.Context) entity.WriteOp {
 	}
 
 	setOp := c.QueryParam("setOp")
-	if setOp == "" {
+	if setOp != "" {
 		wo.SetOp = setOp
 	}
 	setId := c.QueryParam("setId")
-	if setId == "" {
+	if setId != "" {
 		wo.SetId = setId
 	}
 	setSize := c.QueryParam("setSize")
-	if setSize == "" {
+	if setSize != "" {
 		i, _ := strconv.Atoi(setSize)
 		wo.SetSize = i
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/square/etre"
 	"github.com/square/etre/cdc"
@@ -119,7 +120,14 @@ func (api *API) getEntitiesHandler(c echo.Context) error {
 		return handleError(ErrInvalidQuery.New("invalid query: %s", err))
 	}
 
-	entities, err := api.es.ReadEntities(entityType, q)
+	// Query Filter
+	f := etre.QueryFilter{}
+	csvReturnLabels := c.QueryParam("labels")
+	if csvReturnLabels != "" {
+		f.ReturnLabels = strings.Split(csvReturnLabels, ",")
+	}
+
+	entities, err := api.es.ReadEntities(entityType, q, f)
 	if err != nil {
 		return handleError(ErrDb.New("database error: %s", err))
 	}
@@ -268,7 +276,14 @@ func (api *API) getEntityHandler(c echo.Context) error {
 
 	q := queryForId(entityId)
 
-	entities, err := api.es.ReadEntities(entityType, q)
+	// Query Filter
+	f := etre.QueryFilter{}
+	csvReturnLabels := c.QueryParam("labels")
+	if csvReturnLabels != "" {
+		f.ReturnLabels = strings.Split(csvReturnLabels, ",")
+	}
+
+	entities, err := api.es.ReadEntities(entityType, q, f)
 	if err != nil {
 		return handleError(ErrDb.New(err.Error()))
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -295,9 +295,9 @@ func (api *API) getEntityHandler(c echo.Context) error {
 
 	if len(entities) == 0 {
 		return c.JSON(http.StatusNotFound, nil)
-	} else {
-		return c.JSON(http.StatusOK, entities[0])
 	}
+
+	return c.JSON(http.StatusOK, entities[0])
 }
 
 func (api *API) putEntityHandler(c echo.Context) error {
@@ -319,6 +319,11 @@ func (api *API) putEntityHandler(c echo.Context) error {
 	if entities == nil && err != nil {
 		return handleError(ErrDb.New(err.Error()))
 	}
+
+	if len(entities) == 0 {
+		return c.JSON(http.StatusNotFound, nil)
+	}
+
 	wr := api.WriteResults(entities, err)
 
 	return c.JSON(http.StatusOK, wr[0])
@@ -337,6 +342,11 @@ func (api *API) deleteEntityHandler(c echo.Context) error {
 	if entities == nil && err != nil {
 		return handleError(ErrDb.New(err.Error()))
 	}
+
+	if len(entities) == 0 {
+		return c.JSON(http.StatusNotFound, nil)
+	}
+
 	wr := api.WriteResults(entities, err)
 
 	return c.JSON(http.StatusOK, wr[0])
@@ -522,7 +532,8 @@ func queryForId(id string) query.Query {
 // language we use only supports querying by string or int. See more at:
 // github.com/square/etre/query
 func validValueType(v interface{}) bool {
-	return reflect.TypeOf(v).Kind() == reflect.String || reflect.TypeOf(v).Kind() == reflect.Int
+	k := reflect.TypeOf(v).Kind()
+	return k == reflect.String || k == reflect.Int || k == reflect.Bool
 }
 
 func validateParams(c echo.Context, needEntityId bool) error {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
+	"github.com/square/etre/entity"
 	"github.com/square/etre/query"
 	"github.com/square/etre/test"
 	"github.com/square/etre/test/mock"
@@ -36,7 +37,6 @@ var (
 	seedEntities                          []etre.Entity
 )
 
-var mongoURL = "monogdb://localhost/etre_test?replicaSet=etre"
 var addr = "http://localhost"
 var entityType = "nodes"
 
@@ -47,16 +47,16 @@ var mu = &sync.Mutex{}
 func setup(t *testing.T) {
 	if defaultServer == nil {
 		es := &mock.EntityStore{
-			CreateEntitiesFunc: func(string, []etre.Entity, string) ([]string, error) {
+			CreateEntitiesFunc: func(entity.WriteOp, []etre.Entity) ([]string, error) {
 				return createIds, createErr
 			},
-			ReadEntitiesFunc: func(string, query.Query) ([]etre.Entity, error) {
+			ReadEntitiesFunc: func(string, query.Query, etre.QueryFilter) ([]etre.Entity, error) {
 				return seedEntities, readErr
 			},
-			UpdateEntitiesFunc: func(string, query.Query, etre.Entity, string) ([]etre.Entity, error) {
+			UpdateEntitiesFunc: func(entity.WriteOp, query.Query, etre.Entity) ([]etre.Entity, error) {
 				return updateEntities, updateErr
 			},
-			DeleteEntitiesFunc: func(string, query.Query, string) ([]etre.Entity, error) {
+			DeleteEntitiesFunc: func(entity.WriteOp, query.Query) ([]etre.Entity, error) {
 				return deleteEntities, deleteErr
 			},
 		}

--- a/bin/etre/main.go
+++ b/bin/etre/main.go
@@ -66,7 +66,7 @@ func main() {
 		Server: config.ServerConfig{
 			Addr: default_addr,
 		},
-		Datasource: DatasourceConfig{
+		Datasource: config.DatasourceConfig{
 			URL:      default_datasource_url,
 			Database: default_database,
 			Timeout:  default_database_timeout_seconds,

--- a/bin/etre/main.go
+++ b/bin/etre/main.go
@@ -29,7 +29,7 @@ var flagConfig string
 var default_addr = "127.0.0.1:8080"
 var default_datasource_url = "localhost"
 var default_database = "etre"
-var default_entity_types = []string{"node"} // @todo: remove
+var default_entity_types = []string{}
 var default_database_timeout_seconds = 5
 var default_cdc_collection = "" // disabled
 var default_delay_collection = "delay"

--- a/cdc_client.go
+++ b/cdc_client.go
@@ -100,9 +100,12 @@ func (c *cdcClient) Start(startTs time.Time) (<-chan CDCEvent, error) {
 	c.debug("connecting to %s", c.addr)
 	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
 	if err != nil {
-		defer resp.Body.Close()
-		body, _ := ioutil.ReadAll(resp.Body)
-		return nil, apiError(resp, body)
+		if resp != nil {
+			defer resp.Body.Close()
+			body, _ := ioutil.ReadAll(resp.Body)
+			return nil, apiError(resp, body)
+		}
+		return nil, fmt.Errorf("websocket.DefaultDialer.Dial(%s): %s", u.String(), err)
 	}
 	c.wsConn = conn
 

--- a/client_test.go
+++ b/client_test.go
@@ -588,13 +588,11 @@ func TestUpdateOneOK(t *testing.T) {
 	setup(t)
 
 	// Set global vars used by httptest.Server
-	respData = []etre.WriteResult{
-		{
-			Id:  "abc",
-			URI: "http://localhost/entity/abc",
-			Diff: map[string]interface{}{
-				"foo": "foo",
-			},
+	respData = etre.WriteResult{
+		Id:  "abc",
+		URI: "http://localhost/entity/abc",
+		Diff: map[string]interface{}{
+			"foo": "foo",
 		},
 	}
 
@@ -617,7 +615,7 @@ func TestUpdateOneOK(t *testing.T) {
 	if gotPath != expectPath {
 		t.Errorf("got path %s, expected %s", gotPath, expectPath)
 	}
-	if diff := deep.Equal(got, respData.([]etre.WriteResult)[0]); diff != nil {
+	if diff := deep.Equal(got, respData.(etre.WriteResult)); diff != nil {
 		t.Error(diff)
 	}
 }
@@ -655,11 +653,60 @@ func TestDeleteOK(t *testing.T) {
 		t.Errorf("got method %s, expected DELETE", gotMethod)
 	}
 	expectPath := etre.API_ROOT + "/entities/node"
+	expectQuery := "query=" + query
 	if gotPath != expectPath {
 		t.Errorf("got path %s, expected %s", gotPath, expectPath)
 	}
-	if gotQuery != query {
-		t.Errorf("got query %s, expected %s", gotQuery, query)
+	if gotQuery != expectQuery {
+		t.Errorf("got query %s, expected %s", gotQuery, expectQuery)
+	}
+	if diff := deep.Equal(got, respData); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDeleteWithSet(t *testing.T) {
+	setup(t)
+
+	// Set global vars used by httptest.Server
+	respData = []etre.WriteResult{
+		{
+			Id:  "abc",
+			URI: "http://localhost/entity/abc",
+			Diff: map[string]interface{}{
+				"foo": "foo",
+			},
+		},
+	}
+
+	// New etre.Client
+	ec := etre.NewEntityClient("node", ts.URL, httpClient)
+
+	set := etre.Set{
+		Id:   "setid",
+		Op:   "setop",
+		Size: 3,
+	}
+	ec = ec.WithSet(set)
+
+	// Normal delete that returns status code 200 and a write result
+	query := "foo=bar"
+	got, err := ec.Delete(query)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify call and response
+	if gotMethod != "DELETE" {
+		t.Errorf("got method %s, expected DELETE", gotMethod)
+	}
+	expectPath := etre.API_ROOT + "/entities/node"
+	expectQuery := "query=" + query + "&setId=setid&setOp=setop&setSize=3"
+	if gotPath != expectPath {
+		t.Errorf("got path %s, expected %s", gotPath, expectPath)
+	}
+	if gotQuery != expectQuery {
+		t.Errorf("got query %s, expected %s", gotQuery, expectQuery)
 	}
 	if diff := deep.Equal(got, respData); diff != nil {
 		t.Error(diff)
@@ -674,13 +721,11 @@ func TestDeleteOneOK(t *testing.T) {
 	setup(t)
 
 	// Set global vars used by httptest.Server
-	respData = []etre.WriteResult{
-		{
-			Id:  "abc",
-			URI: "http://localhost/entity/abc",
-			Diff: map[string]interface{}{
-				"foo": "foo",
-			},
+	respData = etre.WriteResult{
+		Id:  "abc",
+		URI: "http://localhost/entity/abc",
+		Diff: map[string]interface{}{
+			"foo": "foo",
 		},
 	}
 
@@ -695,15 +740,51 @@ func TestDeleteOneOK(t *testing.T) {
 	if gotMethod != "DELETE" {
 		t.Errorf("got method %s, expected DELETE", gotMethod)
 	}
-	expectPath := etre.API_ROOT + "/entities/node"
+	expectPath := etre.API_ROOT + "/entity/node/abc"
 	if gotPath != expectPath {
 		t.Errorf("got path %s, expected %s", gotPath, expectPath)
 	}
-	expectQuery := etre.META_LABEL_ID + "=abc"
+	if diff := deep.Equal(got, respData.(etre.WriteResult)); diff != nil {
+		t.Error(diff)
+	}
+}
+
+func TestDeleteOneWithSet(t *testing.T) {
+	setup(t)
+
+	respData = etre.WriteResult{
+		Id:  "abc",
+		URI: "http://localhost/entity/abc",
+		Diff: map[string]interface{}{
+			"foo": "foo",
+		},
+	}
+
+	ec := etre.NewEntityClient("node", ts.URL, httpClient)
+
+	set := etre.Set{
+		Id:   "setid",
+		Op:   "setop",
+		Size: 2,
+	}
+	ec = ec.WithSet(set)
+
+	got, err := ec.DeleteOne("abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMethod != "DELETE" {
+		t.Errorf("got method %s, expected DELETE", gotMethod)
+	}
+	expectPath := etre.API_ROOT + "/entity/node/abc"
+	expectQuery := "setId=setid&setOp=setop&setSize=2"
+	if gotPath != expectPath {
+		t.Errorf("got path %s, expected %s", gotPath, expectPath)
+	}
 	if gotQuery != expectQuery {
 		t.Errorf("got query %s, expected %s", gotQuery, expectQuery)
 	}
-	if diff := deep.Equal(got, respData.([]etre.WriteResult)[0]); diff != nil {
+	if diff := deep.Equal(got, respData.(etre.WriteResult)); diff != nil {
 		t.Error(diff)
 	}
 }
@@ -742,13 +823,11 @@ func TestDeleteLabelOK(t *testing.T) {
 	setup(t)
 
 	// Set global vars used by httptest.Server
-	respData = []etre.WriteResult{
-		{
-			Id:  "abc",
-			URI: "http://localhost/entity/abc",
-			Diff: map[string]interface{}{
-				"foo": "foo",
-			},
+	respData = etre.WriteResult{
+		Id:  "abc",
+		URI: "http://localhost/entity/abc",
+		Diff: map[string]interface{}{
+			"foo": "foo",
 		},
 	}
 
@@ -767,7 +846,7 @@ func TestDeleteLabelOK(t *testing.T) {
 	if gotPath != expectPath {
 		t.Errorf("got path %s, expected %s", gotPath, expectPath)
 	}
-	if diff := deep.Equal(got, respData.([]etre.WriteResult)[0]); diff != nil {
+	if diff := deep.Equal(got, respData.(etre.WriteResult)); diff != nil {
 		t.Error(diff)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -174,6 +174,7 @@ func TestQueryOK(t *testing.T) {
 
 	// Normal query that returns status code 200 and respData
 	query := "x=y"
+	expectQuery := "query=" + query
 	got, err := ec.Query(query, etre.QueryFilter{})
 	if err != nil {
 		t.Fatal(err)
@@ -184,8 +185,8 @@ func TestQueryOK(t *testing.T) {
 	if gotPath != expectPath {
 		t.Errorf("got path %s, expected %s", gotPath, expectPath)
 	}
-	if gotQuery != query {
-		t.Errorf("got query %s, expected %s", gotQuery, query)
+	if gotQuery != expectQuery {
+		t.Errorf("got query %s, expected %s", gotQuery, expectQuery)
 	}
 	if diff := deep.Equal(got, respData); diff != nil {
 		t.Error(diff)

--- a/client_test.go
+++ b/client_test.go
@@ -423,42 +423,6 @@ func TestInsertNoEntityError(t *testing.T) {
 	}
 }
 
-func TestInsertMetalabelErrors(t *testing.T) {
-	setup(t)
-
-	ec := etre.NewEntityClient("node", ts.URL, httpClient)
-
-	// _id is not allowed on insert
-	entities := []etre.Entity{
-		{
-			"_id": "abc", // not allowed
-			"foo": "bar",
-		},
-	}
-	got, err := ec.Insert(entities)
-	if err != etre.ErrIdSet {
-		t.Fatalf("err is '%s', expected ErrIdSet", err)
-	}
-	if got != nil {
-		t.Errorf("got []etre.WriteResult, expected nil: %#v", got)
-	}
-
-	// _type must match Client type (node ^)
-	entities = []etre.Entity{
-		{
-			"_type": "wrong", // wrong
-			"foo":   "bar",
-		},
-	}
-	got, err = ec.Insert(entities)
-	if err != etre.ErrTypeMismatch {
-		t.Fatalf("err is '%s', expected ErrTypeMismatch", err)
-	}
-	if got != nil {
-		t.Errorf("got []etre.WriteResult, expected nil: %#v", got)
-	}
-}
-
 // //////////////////////////////////////////////////////////////////////////
 // Update
 // //////////////////////////////////////////////////////////////////////////
@@ -542,38 +506,6 @@ func TestUpdateNoEntityError(t *testing.T) {
 	got, err := ec.Update("foo=bar", entity)
 	if err != etre.ErrNoEntity {
 		t.Fatalf("err is '%s', expected ErrNoEtity", err)
-	}
-	if got != nil {
-		t.Errorf("got []etre.WriteResult, expected nil: %#v", got)
-	}
-}
-
-func TestUpdateMetalabelErrors(t *testing.T) {
-	setup(t)
-
-	ec := etre.NewEntityClient("node", ts.URL, httpClient)
-
-	// _id is not allowed on update patch
-	entity := etre.Entity{
-		etre.META_LABEL_ID: "abc",
-		"foo":              "bar",
-	}
-	got, err := ec.Update("foo=bar", entity)
-	if err != etre.ErrIdSet {
-		t.Fatalf("err is '%s', expected ErrIdSet", err)
-	}
-	if got != nil {
-		t.Errorf("got []etre.WriteResult, expected nil: %#v", got)
-	}
-
-	// _type must match Client type (node ^)
-	entity = etre.Entity{
-		"_type": "wrong", // wrong
-		"foo":   "bar",
-	}
-	got, err = ec.Update("foo=bar", entity)
-	if err != etre.ErrTypeMismatch {
-		t.Fatalf("err is '%s', expected ErrTypeMismatch", err)
 	}
 	if got != nil {
 		t.Errorf("got []etre.WriteResult, expected nil: %#v", got)

--- a/entity/store_test.go
+++ b/entity/store_test.go
@@ -81,7 +81,6 @@ func teardown(t *testing.T, es entity.Store) {
 func TestCreateNewStoreError(t *testing.T) {
 	// This is invalid because it's a reserved name
 	invalidEntityType := "entities"
-	expectedErrMsg := fmt.Sprintf("entity type %s is a reserved word", invalidEntityType)
 	_, err := entity.NewStore(&mock.Connector{}, database, []string{invalidEntityType}, &mock.CDCStore{}, &mock.Delayer{})
 	if !strings.Contains(err.Error(), "reserved word") {
 		t.Errorf("err = %s, expected to contain 'reserved word'", err)

--- a/entity_client.go
+++ b/entity_client.go
@@ -97,7 +97,7 @@ func (c entityClient) Query(query string, filter QueryFilter) ([]Entity, error) 
 	)
 	if len(query) < 2000 {
 		query = url.QueryEscape(query) // always escape the query
-		resp, bytes, err = c.do("GET", "/entities/"+c.entityType+"?"+query, nil)
+		resp, bytes, err = c.do("GET", "/entities/"+c.entityType+"?query="+query, nil)
 	} else {
 		// _DO NOT ESCAPE QUERY!_ It's not sent via URL, so no escaping needed.
 		resp, bytes, err = c.do("POST", "/query/"+c.entityType, []byte(query))
@@ -305,6 +305,9 @@ func (c entityClient) url(endpoint string) string {
 }
 
 func apiError(resp *http.Response, bytes []byte) error {
+	if resp == nil {
+		return fmt.Errorf("no response from API; check API logs for errors")
+	}
 	var errResp Error
 	if len(bytes) > 0 {
 		json.Unmarshal(bytes, &errResp)

--- a/entity_client.go
+++ b/entity_client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // EntityClient represents a entity type-specific client. No interface method has
@@ -97,7 +98,12 @@ func (c entityClient) Query(query string, filter QueryFilter) ([]Entity, error) 
 	)
 	if len(query) < 2000 {
 		query = url.QueryEscape(query) // always escape the query
-		resp, bytes, err = c.do("GET", "/entities/"+c.entityType+"?query="+query, nil)
+		url := "/entities/" + c.entityType + "?query=" + query
+		if len(filter.ReturnLabels) > 0 {
+			rl := strings.Join(filter.ReturnLabels, ",")
+			url += "&labels=" + rl
+		}
+		resp, bytes, err = c.do("GET", url, nil)
 	} else {
 		// _DO NOT ESCAPE QUERY!_ It's not sent via URL, so no escaping needed.
 		resp, bytes, err = c.do("POST", "/query/"+c.entityType, []byte(query))

--- a/es/app/app.go
+++ b/es/app/app.go
@@ -1,0 +1,53 @@
+// Copyright 2017, Square, Inc.
+
+// Package app provides app-wide data structs and functions.
+package app
+
+import (
+	"io"
+	"log"
+
+	"github.com/square/etre"
+	"github.com/square/etre/es/config"
+)
+
+// Context represents how to run es. A context is passed to es.Run().
+// A default context is created in main.go. Wrapper code can integrate with
+// es by passing a custom context to es.Run(). Integration is done
+// primarily with hooks and factories.
+type Context struct {
+	// Set in main.go or by wrapper
+	In        io.Reader // where to read user input (default: stdin)
+	Out       io.Writer // where to print output (default: stdout)
+	Hooks     Hooks     // for integration with other code
+	Factories Factories // for integration with other code
+
+	// Set automatically in es.Run()
+	Options      config.Options // command line options (--addr, etc.)
+	EntityType   string
+	ReturnLabels []string
+	Query        string
+}
+
+type EntityClientFactory interface {
+	Make(Context) (etre.EntityClient, error)
+}
+
+type Factories struct {
+	EntityClient EntityClientFactory
+}
+
+type Hooks struct {
+	AfterParseOptions func(*config.Options)
+	BeforeQuery       func(*Context) error
+	Response          func(Context, []etre.Entity, error)
+}
+
+func init() {
+	log.SetPrefix("DEBUG ")
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.Lshortfile)
+}
+
+func Debug(fmt string, v ...interface{}) {
+	log.Printf(fmt, v...)
+}

--- a/es/app/app.go
+++ b/es/app/app.go
@@ -25,8 +25,10 @@ type Context struct {
 	// Set automatically in es.Run()
 	Options      config.Options // command line options (--addr, etc.)
 	EntityType   string
-	ReturnLabels []string
-	Query        string
+	ReturnLabels []string // query
+	Query        string   // query
+	EntityId     string   // --update and --delete
+	Patches      []string // --update
 }
 
 type EntityClientFactory interface {
@@ -40,7 +42,10 @@ type Factories struct {
 type Hooks struct {
 	AfterParseOptions func(*config.Options)
 	BeforeQuery       func(*Context) error
-	Response          func(Context, []etre.Entity, error)
+	AfterQuery        func(Context, []etre.Entity, error)
+	BeforeDelete      func(ctx *Context) error
+	BeforeUpdate      func(cxt *Context) error
+	WriteResult       func(Context, etre.WriteResult, error)
 }
 
 func init() {

--- a/es/bin/main.go
+++ b/es/bin/main.go
@@ -1,0 +1,32 @@
+// Copyright 2017, Square, Inc.
+
+package main
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/square/etre"
+	"github.com/square/etre/es"
+	"github.com/square/etre/es/app"
+)
+
+// Default etre.EntityClient factory
+type ecFactory struct{}
+
+func (f ecFactory) Make(ctx app.Context) (etre.EntityClient, error) {
+	ec := etre.NewEntityClient(ctx.EntityType, ctx.Options.Addr, &http.Client{})
+	return ec, nil
+}
+
+func main() {
+	defaultContext := app.Context{
+		In:    os.Stdin,
+		Out:   os.Stdout,
+		Hooks: app.Hooks{},
+		Factories: app.Factories{
+			EntityClient: ecFactory{},
+		},
+	}
+	es.Run(defaultContext)
+}

--- a/es/config/config.go
+++ b/es/config/config.go
@@ -39,9 +39,12 @@ type Options struct {
 	IFS     string `arg:"env" yaml:"ifs"`
 	Labels  bool   `arg:"env" yaml:"labels"`
 	Ping    bool
-	Old     bool `arg:"env" yaml:"old"`
-	Strict  bool `arg:"env" yaml:"strict"`
-	Timeout uint `arg:"env" yaml:"timeout"`
+	Old     bool   `arg:"env" yaml:"old"`
+	SetOp   string `arg:"--set-op,env:SET_OP"`
+	SetId   string `arg:"--set-id,env:SET_ID"`
+	SetSize int    `arg:"--set-size,env:SET_SIZE"`
+	Strict  bool   `arg:"env" yaml:"strict"`
+	Timeout uint   `arg:"env" yaml:"timeout"`
 	Update  bool
 	Version bool
 }
@@ -106,7 +109,10 @@ func Help() {
 		"  --labels   Print label: before value\n"+
 		"  --ping     Ping addr\n"+
 		"  --old      Print old values on --update\n"+
-		"  --strict   Error if --delete does not match an entity\n"+
+		"  --set-id   User-defined set ID for --update and --delete\n"+
+		"  --set-op   User-defined set op for --update and --delete\n"+
+		"  --set-size User-defined set size for --update and --delete (must be > 0)\n"+
+		"  --strict   Error if query or --delete does not match entities\n"+
 		"  --timeout  API timeout, milliseconds (default: %d)\n"+
 		"  --update   Apply patches to one entity by id\n"+
 		"  --version  Print version\n\n",

--- a/es/config/config.go
+++ b/es/config/config.go
@@ -18,10 +18,9 @@ import (
 )
 
 const (
-	DEFAULT_CONFIG_FILES  = "/etc/etre/es.yaml,~/.es.yaml"
-	DEFAULT_IFS           = ","
-	DEFAULT_OUTPUT_FORMAT = "line"
-	DEFAULT_TIMEOUT       = 10000 // 10s
+	DEFAULT_CONFIG_FILES = "/etc/etre/es.yaml,~/.es.yaml"
+	DEFAULT_IFS          = ","
+	DEFAULT_TIMEOUT      = 10000 // 10s
 )
 
 var (
@@ -30,16 +29,21 @@ var (
 
 // Options represents typical command line options: --addr, --config, etc.
 type Options struct {
-	Addr         string `arg:"env" yaml:"addr"`
-	Config       string `arg:"env"`
-	Debug        bool
-	Env          string
-	Help         bool
-	IFS          string `arg:"env" yaml:"ifs"`
-	OutputFormat string `arg:"env" yaml:"output-format"`
-	Ping         bool
-	Timeout      uint `arg:"env" yaml:"timeout"`
-	Version      bool
+	Addr    string `arg:"env" yaml:"addr"`
+	Config  string `arg:"env"`
+	Debug   bool
+	Delete  bool
+	Env     string
+	Help    bool
+	JSON    bool   `arg:"env" yaml:"json"`
+	IFS     string `arg:"env" yaml:"ifs"`
+	Labels  bool   `arg:"env" yaml:"labels"`
+	Ping    bool
+	Old     bool `arg:"env" yaml:"old"`
+	Strict  bool `arg:"env" yaml:"strict"`
+	Timeout uint `arg:"env" yaml:"timeout"`
+	Update  bool
+	Version bool
 }
 
 // CommandLine represents options (--addr, etc.) and args: entity type, return
@@ -80,19 +84,33 @@ func ParseCommandLine(def Options) CommandLine {
 }
 
 func Help() {
-	fmt.Printf("Usage: es [flags] entity[.label,...] query\n\n"+
-		"Flags:\n"+
-		"  --addr          Address of Request Managers (https://local.domain:8080)\n"+
-		"  --config        Config files (default: %s)\n"+
-		"  --debug         Print debug to stderr\n"+
-		"  --env           Environment (dev, staging, production)\n"+
-		"  --help          Print help\n"+
-		"  --ifs           Internal field separator to print between label values for line output (default: %s)\n"+
-		"  --output-format Output format to print entities: line or json (default: %s)\n"+
-		"  --ping          Ping addr\n"+
-		"  --timeout       API timeout, milliseconds (default: %d)\n"+
-		"  --version       Print version\n",
-		DEFAULT_CONFIG_FILES, DEFAULT_IFS, DEFAULT_OUTPUT_FORMAT, DEFAULT_TIMEOUT)
+	fmt.Printf("Usage:\n"+
+		"   Query: es [options] entity[.label,...] query\n"+
+		"  Update: es [options] --update entity id\n"+
+		"  Delete: es [options] --update entity id patches\n\n"+
+		"Args:\n"+
+		"  entity     Valid entity type (Etre API config.entity.types)\n"+
+		"  label      Comma-separated list of labels to return, like: host.zone,env\n"+
+		"  query      Query string, like: env=production, zone in (east, west)\n"+
+		"  id         Internal ID (_id) of an entity, like: 507f1f77bcf86cd799439011\n"+
+		"  patches    New label=value pairs, like: zone=west status=online\n\n"+
+		"Options:\n"+
+		"  --addr     Etre API address (example: http://localhost:8080)\n"+
+		"  --config   Config files (default: %s)\n"+
+		"  --debug    Print debug to stderr\n"+
+		"  --delete   Delete one entity by id\n"+
+		"  --env      Environment (dev, staging, production)\n"+
+		"  --help     Print help\n"+
+		"  --ifs      Character to print between label values (default: %s)\n"+
+		"  --json     Print entities as JSON\n"+
+		"  --labels   Print label: before value\n"+
+		"  --ping     Ping addr\n"+
+		"  --old      Print old values on --update\n"+
+		"  --strict   Error if --delete does not match an entity\n"+
+		"  --timeout  API timeout, milliseconds (default: %d)\n"+
+		"  --update   Apply patches to one entity by id\n"+
+		"  --version  Print version\n\n",
+		DEFAULT_CONFIG_FILES, DEFAULT_IFS, DEFAULT_TIMEOUT)
 }
 
 func ParseConfigFiles(files string, debug bool) Options {

--- a/es/config/config.go
+++ b/es/config/config.go
@@ -1,0 +1,173 @@
+// Copyright 2017, Square, Inc.
+
+// Package config handles config files, -config, and env vars at startup.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/alexflint/go-arg"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	DEFAULT_CONFIG_FILES  = "/etc/etre/es.yaml,~/.es.yaml"
+	DEFAULT_IFS           = ","
+	DEFAULT_OUTPUT_FORMAT = "line"
+	DEFAULT_TIMEOUT       = 10000 // 10s
+)
+
+var (
+	ErrUnknownRequest = errors.New("request does not exist")
+)
+
+// Options represents typical command line options: --addr, --config, etc.
+type Options struct {
+	Addr         string `arg:"env" yaml:"addr"`
+	Config       string `arg:"env"`
+	Debug        bool
+	Env          string
+	Help         bool
+	IFS          string `arg:"env" yaml:"ifs"`
+	OutputFormat string `arg:"env" yaml:"output-format"`
+	Ping         bool
+	Timeout      uint `arg:"env" yaml:"timeout"`
+	Version      bool
+}
+
+// CommandLine represents options (--addr, etc.) and args: entity type, return
+// labels, and query predicates. The caller is expected to copy and use the embedded
+// structs separately, like:
+//
+//   var o config.Options = cmdLine.Options
+//   for i, arg := range cmdline.Args {
+//
+type CommandLine struct {
+	Options
+	Args []string `arg:"positional"`
+}
+
+// ParseCommandLine parses the command line and env vars. Command line options
+// override env vars. Default options are used unless overridden by env vars or
+// command line options. Defaults are usually parsed from config files.
+func ParseCommandLine(def Options) CommandLine {
+	var c CommandLine
+	c.Options = def
+	p, err := arg.NewParser(arg.Config{Program: "es"}, &c)
+	if err != nil {
+		fmt.Printf("arg.NewParser: %s", err)
+		os.Exit(1)
+	}
+	if err := p.Parse(os.Args[1:]); err != nil {
+		switch err {
+		case arg.ErrHelp:
+			c.Help = true
+		case arg.ErrVersion:
+			c.Version = true
+		default:
+			fmt.Printf("Error parsing command line: %s\n", err)
+			os.Exit(1)
+		}
+	}
+	return c
+}
+
+func Help() {
+	fmt.Printf("Usage: es [flags] entity[.label,...] query\n\n"+
+		"Flags:\n"+
+		"  --addr          Address of Request Managers (https://local.domain:8080)\n"+
+		"  --config        Config files (default: %s)\n"+
+		"  --debug         Print debug to stderr\n"+
+		"  --env           Environment (dev, staging, production)\n"+
+		"  --help          Print help\n"+
+		"  --ifs           Internal field separator to print between label values for line output (default: %s)\n"+
+		"  --output-format Output format to print entities: line or json (default: %s)\n"+
+		"  --ping          Ping addr\n"+
+		"  --timeout       API timeout, milliseconds (default: %d)\n"+
+		"  --version       Print version\n",
+		DEFAULT_CONFIG_FILES, DEFAULT_IFS, DEFAULT_OUTPUT_FORMAT, DEFAULT_TIMEOUT)
+}
+
+func ParseConfigFiles(files string, debug bool) Options {
+	var def Options
+	for _, file := range strings.Split(files, ",") {
+		// If file starts with ~/, we need to expand this to the user home dir
+		// because this is a shell expansion, not something Go knows about.
+		if file[:2] == "~/" {
+			usr, _ := user.Current()
+			file = filepath.Join(usr.HomeDir, file[2:])
+		}
+
+		absfile, err := filepath.Abs(file)
+		if err != nil {
+			if debug {
+				log.Printf("filepath.Abs(%s) error: %s", file, err)
+			}
+			continue
+		}
+
+		bytes, err := ioutil.ReadFile(absfile)
+		if err != nil {
+			if debug {
+				log.Printf("Cannot read config file %s: %s", file, err)
+			}
+			continue
+		}
+
+		var o Options
+		if err := yaml.Unmarshal(bytes, &o); err != nil {
+			if debug {
+				log.Printf("Invalid YAML in config file %s: %s", file, err)
+			}
+			continue
+		}
+
+		// Set options from this config file only if they're set
+		if debug {
+			log.Printf("Applying config file %s (%s)", file, absfile)
+		}
+		if o.Addr != "" {
+			def.Addr = o.Addr
+		}
+		if o.Timeout != 0 {
+			def.Timeout = o.Timeout
+		}
+	}
+	return def
+}
+
+func ParseArgs(args []string) (string, []string, string) {
+	if len(args) == 0 {
+		return "", nil, ""
+	}
+
+	// Example inputs:
+	// args 0        1   2
+	//      node     a=b
+	//      node.x   a=b
+	//      node.x,y a=b
+	//      node.z   a=b c=d
+
+	entityType := args[0]
+	var returnLabels []string
+
+	p := strings.Split(entityType, ".")
+	if len(p) == 2 {
+		entityType = p[0]
+		returnLabels = strings.Split(p[1], ",")
+	}
+
+	var query string
+	if len(args) > 1 {
+		query = strings.Join(args[1:], " ")
+	}
+
+	return entityType, returnLabels, query
+}

--- a/es/es.go
+++ b/es/es.go
@@ -117,7 +117,8 @@ func Run(ctx app.Context) {
 	// //////////////////////////////////////////////////////////////////////
 
 	// cmdLine.Args validated above
-	ctx.EntityType = cmdLine.Args[0]
+	entityType := strings.SplitN(cmdLine.Args[0], ".", 2)
+	ctx.EntityType = entityType[0]
 
 	if ctx.Options.Addr == "" {
 		fmt.Fprintf(os.Stderr, "Etre API address is not set."+
@@ -266,7 +267,9 @@ func Run(ctx app.Context) {
 
 	// Parse args: entity[.labels] query
 	ctx.EntityType, ctx.ReturnLabels, ctx.Query = config.ParseArgs(cmdLine.Args)
-	app.Debug("query: %s %s '%s'\n", ctx.EntityType, ctx.ReturnLabels, ctx.Query)
+	if o.Debug {
+		app.Debug("query: %s %s '%s'\n", ctx.EntityType, ctx.ReturnLabels, ctx.Query)
+	}
 
 	if ctx.Hooks.BeforeQuery != nil {
 		if o.Debug {
@@ -297,12 +300,15 @@ func Run(ctx app.Context) {
 
 	// Else, do the default: print the entities, if no error.
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "API error: %s\n", err)
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 
 	// No entities? No fun. :-(
 	if len(entities) == 0 {
+		if ctx.Options.Strict {
+			os.Exit(1)
+		}
 		return
 	}
 

--- a/es/es.go
+++ b/es/es.go
@@ -1,0 +1,215 @@
+// Copyright 2017, Square, Inc.
+
+// Package es provides a framework for integration with other programs.
+package es
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/square/etre"
+	"github.com/square/etre/es/app"
+	"github.com/square/etre/es/config"
+)
+
+// Run runs es and exits when done. When using a standard es bin, Run is
+// called by es/bin/main.go. When es is wrapped by custom code, that code
+// imports this pkg then call es.Run() with its custom factories. If a factory
+// is not set (nil), then the default/standard factory is used.
+func Run(ctx app.Context) {
+	// //////////////////////////////////////////////////////////////////////
+	// Config and command line
+	// //////////////////////////////////////////////////////////////////////
+
+	// Options are set in this order: config -> env var -> cmd line option.
+	// So first we must apply config files, then do cmd line parsing which
+	// will apply env vars and cmd line options.
+
+	// Parse cmd line to get --config files
+	cmdLine := config.ParseCommandLine(config.Options{})
+
+	// --config files override defaults if given
+	configFiles := config.DEFAULT_CONFIG_FILES
+	if cmdLine.Config != "" {
+		configFiles = cmdLine.Config
+	}
+
+	// Parse default options from config files
+	def := config.ParseConfigFiles(configFiles, cmdLine.Debug)
+	if def.IFS == "" {
+		def.IFS = config.DEFAULT_IFS
+	}
+	if def.OutputFormat == "" {
+		def.OutputFormat = config.DEFAULT_OUTPUT_FORMAT
+	}
+	if def.Timeout == 0 {
+		def.Timeout = config.DEFAULT_TIMEOUT
+	}
+
+	// Parse env vars and cmd line options, override default config
+	cmdLine = config.ParseCommandLine(def)
+
+	// Parse args: entity[.labels] query
+	if len(cmdLine.Args) == 0 {
+		config.Help()
+		os.Exit(0)
+	}
+	if len(cmdLine.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Not enough arguments: entity and query are required\n")
+		config.Help()
+		os.Exit(1)
+	}
+	ctx.EntityType, ctx.ReturnLabels, ctx.Query = config.ParseArgs(cmdLine.Args)
+
+	// Finalize options
+	var o config.Options = cmdLine.Options
+	if o.Debug {
+		app.Debug("options: %#v\n", o)
+		app.Debug("query: %s %s '%s'\n", ctx.EntityType, ctx.ReturnLabels, ctx.Query)
+	}
+
+	if ctx.Hooks.AfterParseOptions != nil {
+		if o.Debug {
+			app.Debug("calling hook AfterParseOptions")
+		}
+		ctx.Hooks.AfterParseOptions(&o)
+
+		// Dump options again to see if hook changed them
+		if o.Debug {
+			app.Debug("options: %#v\n", o)
+		}
+	}
+	ctx.Options = o
+
+	// //////////////////////////////////////////////////////////////////////
+	// Help and version
+	// //////////////////////////////////////////////////////////////////////
+
+	// es with no args (Args[0] = "es" itself). Print short request help
+	// because Ryan is very busy.
+	if len(os.Args) == 1 || o.Help {
+		config.Help()
+		os.Exit(0)
+	}
+
+	// es --version or es version
+	if o.Version {
+		fmt.Println("es v0.0.0")
+		os.Exit(0)
+	}
+
+	// //////////////////////////////////////////////////////////////////////
+	// Make etre.EntityClient
+	// //////////////////////////////////////////////////////////////////////
+
+	if ctx.Options.Addr == "" {
+		fmt.Fprintf(os.Stderr, "Etre API address is not set."+
+			" It is best to specify addr in a config file (%s). Or, specify"+
+			" --addr on the command line option or set the ADDR environment"+
+			" variable. Use --ping to test addr when set.\n", config.DEFAULT_CONFIG_FILES)
+		os.Exit(1)
+	}
+	if ctx.Options.Debug {
+		app.Debug("addr: %s", ctx.Options.Addr)
+	}
+
+	ec, err := ctx.Factories.EntityClient.Make(ctx)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error making etre.EntityClient: %s", err)
+		os.Exit(1)
+	}
+
+	// //////////////////////////////////////////////////////////////////////
+	// Ping
+	// //////////////////////////////////////////////////////////////////////
+
+	if o.Ping {
+		// @todo
+		fmt.Printf("-ping todo")
+		os.Exit(0)
+	}
+
+	// //////////////////////////////////////////////////////////////////////
+	// Query
+	// //////////////////////////////////////////////////////////////////////
+
+	if ctx.Hooks.BeforeQuery != nil {
+		if o.Debug {
+			app.Debug("calling hook BeforeQuery")
+		}
+		ctx.Hooks.BeforeQuery(&ctx)
+		if o.Debug {
+			app.Debug("query: %s %s '%s'\n", ctx.EntityType, ctx.ReturnLabels, ctx.Query)
+		}
+	}
+
+	f := etre.QueryFilter{
+		ReturnLabels: ctx.ReturnLabels,
+	}
+	entities, err := ec.Query(ctx.Query, f)
+	if o.Debug {
+		app.Debug("%d entities, err: %v", len(entities), err)
+	}
+
+	// //////////////////////////////////////////////////////////////////////
+	// Handle response
+	// //////////////////////////////////////////////////////////////////////
+
+	// If Response hook set, let it handle the reponse.
+	if ctx.Hooks.Response != nil {
+		if o.Debug {
+			app.Debug("calling hook Response")
+		}
+		ctx.Hooks.Response(ctx, entities, err)
+		return
+	}
+
+	// Else, do the default: print the entities, if no error.
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "API error: %s\n", err)
+		os.Exit(1)
+	}
+
+	// No entities? No fun. :-(
+	if len(entities) == 0 {
+		return
+	}
+
+	switch ctx.Options.OutputFormat {
+	case "line":
+		// Yay, entities! If no return labels were specified, then Etre will have
+		// returned complete entities (i.e. all labels), so default to that.
+		returnLabels := ctx.ReturnLabels
+		if len(ctx.ReturnLabels) == 0 {
+			returnLabels = entities[0].Labels() // all labels, sorted
+		}
+		lastLabel := len(returnLabels) - 1 // don't print IFS after last label
+
+		// Print every label value, in order of returnLabels. So if user queried
+		// host.b,a,t then print values for b,a,t in that exact order. This is
+		// critical because user might be doing this:
+		//
+		//   IFS=,
+		//   set $target
+		//
+		// Which sets Bash $1=b, $2=a, $3=t. Of course, if user did not specify
+		// return labels, they'll get all labels (above), sorted by label name.
+		for _, e := range entities {
+			for n, label := range returnLabels {
+				fmt.Print(e[label])
+				if n < lastLabel { // "b,a,t" not "b,a,t,"
+					fmt.Print(ctx.Options.IFS)
+				}
+			}
+			fmt.Println()
+		}
+	case "json":
+		bytes, err := json.Marshal(entities)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintln(ctx.Out, string(bytes))
+	}
+}

--- a/etre.go
+++ b/etre.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 )
 
 const (
@@ -51,14 +52,15 @@ var metaLabels = map[string]bool{
 	"_type":    true,
 }
 
+// Labels returns all labels, sorted, including meta-labels (_id, _type, etc.)
 func (e Entity) Labels() []string {
-	labels := make([]string, 0, len(e))
+	labels := make([]string, len(e))
+	i := 0
 	for label := range e {
-		if metaLabels[label] {
-			continue
-		}
-		labels = append(labels, label)
+		labels[i] = label
+		i++
 	}
+	sort.Strings(labels)
 	return labels
 }
 
@@ -73,12 +75,12 @@ func (e Entity) String(label string) string {
 	return ""
 }
 
+// QueryFilter represents filtering options for EntityClient.Query().
 type QueryFilter struct {
-	// ReturnLabels defines labels included in matching entities. An empty map
-	// returns all labels. Else, only labels in the map with a true value are
-	// returned. The internal ID (_id) is always returned unless explicitly
-	// excluded by being set in the map with a false value.
-	ReturnLabels map[string]bool // keyed on label
+	// ReturnLabels defines labels included in matching entities. An empty slice
+	// returns all labels, including meta-labels. Else, only labels in the slice
+	// are returned.
+	ReturnLabels []string
 }
 
 // WriteResult represents the result of a write operation (insert, update, delete)

--- a/etre.go
+++ b/etre.go
@@ -181,14 +181,15 @@ func (e Error) Error() string {
 }
 
 var (
-	ErrTypeMismatch  = errors.New("entity _type and Client entity type are different")
-	ErrIdSet         = errors.New("entity _id is set but not allowed on insert")
-	ErrIdNotSet      = errors.New("entity _id is not set")
-	ErrNoEntity      = errors.New("empty entity or id slice; at least one required")
-	ErrNoLabel       = errors.New("empty label slice; at least one required")
-	ErrNoQuery       = errors.New("empty query string")
-	ErrBadData       = errors.New("data from CDC feed is not event or control")
-	ErrCallerBlocked = errors.New("caller blocked")
+	ErrTypeMismatch   = errors.New("entity _type and Client entity type are different")
+	ErrIdSet          = errors.New("entity _id is set but not allowed on insert")
+	ErrIdNotSet       = errors.New("entity _id is not set")
+	ErrNoEntity       = errors.New("empty entity or id slice; at least one required")
+	ErrNoLabel        = errors.New("empty label slice; at least one required")
+	ErrNoQuery        = errors.New("empty query string")
+	ErrBadData        = errors.New("data from CDC feed is not event or control")
+	ErrCallerBlocked  = errors.New("caller blocked")
+	ErrEntityNotFound = errors.New("entity not found")
 )
 
 // WriteError is a convenience function for returning the WriteResult error, if any,

--- a/etre.go
+++ b/etre.go
@@ -29,17 +29,38 @@ const (
 type Entity map[string]interface{}
 
 func (e Entity) Id() string {
-	return e["_id"].(string)
+	return e[META_LABEL_ID].(string)
 }
 
 func (e Entity) Type() string {
-	return e["_type"].(string)
+	return e[META_LABEL_TYPE].(string)
 }
 
 // Has returns true of the entity has the label, regardless of its value.
 func (e Entity) Has(label string) bool {
 	_, ok := e[label]
 	return ok
+}
+
+// A Set is a user-defined logical grouping of writes (insert, update, delete).
+type Set struct {
+	Id   string
+	Op   string
+	Size int
+}
+
+func (e Entity) Set() Set {
+	set := Set{}
+	if _, ok := e["_setId"]; ok {
+		set.Id = e["_setId"].(string)
+	}
+	if _, ok := e["_setOp"]; ok {
+		set.Op = e["_setOp"].(string)
+	}
+	if _, ok := e["_setSize"]; ok {
+		set.Size = e["_setSize"].(int)
+	}
+	return set
 }
 
 var metaLabels = map[string]bool{
@@ -50,6 +71,10 @@ var metaLabels = map[string]bool{
 	"_setSize": true,
 	"_ts":      true,
 	"_type":    true,
+}
+
+func IsMetalabel(label string) bool {
+	return metaLabels[label]
 }
 
 // Labels returns all labels, sorted, including meta-labels (_id, _type, etc.)

--- a/test/mock/entity.go
+++ b/test/mock/entity.go
@@ -4,48 +4,49 @@ package mock
 
 import (
 	"github.com/square/etre"
+	"github.com/square/etre/entity"
 	"github.com/square/etre/query"
 )
 
 type EntityStore struct {
-	DeleteEntityLabelFunc func(string, string, string) (etre.Entity, error)
-	CreateEntitiesFunc    func(string, []etre.Entity, string) ([]string, error)
-	ReadEntitiesFunc      func(string, query.Query) ([]etre.Entity, error)
-	UpdateEntitiesFunc    func(string, query.Query, etre.Entity, string) ([]etre.Entity, error)
-	DeleteEntitiesFunc    func(string, query.Query, string) ([]etre.Entity, error)
+	ReadEntitiesFunc      func(string, query.Query, etre.QueryFilter) ([]etre.Entity, error)
+	DeleteEntityLabelFunc func(entity.WriteOp, string) (etre.Entity, error)
+	CreateEntitiesFunc    func(entity.WriteOp, []etre.Entity) ([]string, error)
+	UpdateEntitiesFunc    func(entity.WriteOp, query.Query, etre.Entity) ([]etre.Entity, error)
+	DeleteEntitiesFunc    func(entity.WriteOp, query.Query) ([]etre.Entity, error)
 }
 
-func (s *EntityStore) DeleteEntityLabel(entityType string, id string, label string) (etre.Entity, error) {
+func (s *EntityStore) DeleteEntityLabel(wo entity.WriteOp, label string) (etre.Entity, error) {
 	if s.DeleteEntityLabelFunc != nil {
-		return s.DeleteEntityLabelFunc(entityType, id, label)
+		return s.DeleteEntityLabelFunc(wo, label)
 	}
 	return nil, nil
 }
 
-func (s *EntityStore) CreateEntities(entityType string, entities []etre.Entity, user string) ([]string, error) {
+func (s *EntityStore) CreateEntities(wo entity.WriteOp, entities []etre.Entity) ([]string, error) {
 	if s.CreateEntitiesFunc != nil {
-		return s.CreateEntitiesFunc(entityType, entities, user)
+		return s.CreateEntitiesFunc(wo, entities)
 	}
 	return nil, nil
 }
 
-func (s *EntityStore) ReadEntities(entityType string, q query.Query) ([]etre.Entity, error) {
+func (s *EntityStore) ReadEntities(entityType string, q query.Query, f etre.QueryFilter) ([]etre.Entity, error) {
 	if s.ReadEntitiesFunc != nil {
-		return s.ReadEntitiesFunc(entityType, q)
+		return s.ReadEntitiesFunc(entityType, q, f)
 	}
 	return nil, nil
 }
 
-func (s *EntityStore) UpdateEntities(t string, q query.Query, u etre.Entity, user string) ([]etre.Entity, error) {
+func (s *EntityStore) UpdateEntities(wo entity.WriteOp, q query.Query, u etre.Entity) ([]etre.Entity, error) {
 	if s.UpdateEntitiesFunc != nil {
-		return s.UpdateEntitiesFunc(t, q, u, user)
+		return s.UpdateEntitiesFunc(wo, q, u)
 	}
 	return nil, nil
 }
 
-func (s *EntityStore) DeleteEntities(t string, q query.Query, user string) ([]etre.Entity, error) {
+func (s *EntityStore) DeleteEntities(wo entity.WriteOp, q query.Query) ([]etre.Entity, error) {
 	if s.DeleteEntitiesFunc != nil {
-		return s.DeleteEntitiesFunc(t, q, user)
+		return s.DeleteEntitiesFunc(wo, q)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
* Add `es/`, the Etre CLI
* Implement `etre.QueryFilter` end to end
* Implement query params `setId=x&setOp=y&setSize=n` (allows set ops for DELETE)
* Add `entity.WriteOp` to consolidate common method args and handle set ops consistently
* Don't allow metalabels in update
* Always preserve set labels
