### PR TITLE
minor bug fixes

### DIFF
--- a/bin/etre/main.go
+++ b/bin/etre/main.go
@@ -98,7 +98,7 @@ type Config struct {
 
 var flagConfig string
 var default_addr = "127.0.0.1:8080"
-var default_database_url = "localhost"
+var default_datasource_url = "localhost"
 var default_database = "etre"
 var default_entity_types = []string{"node"} // @todo: remove
 var default_database_timeout_seconds = 5
@@ -138,7 +138,7 @@ func main() {
 			Addr: default_addr,
 		},
 		Datasource: DatasourceConfig{
-			URL:      default_database_url,
+			URL:      default_datasource_url,
 			Database: default_database,
 			Timeout:  default_database_timeout_seconds,
 		},

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,7 +8,7 @@
 #   tls-key:
 #   tls-ca:
 #   username_header: username
-# datatsource:
+# datasource:
 #   url: localhost
 #   database: etre
 #   timeout: 5

--- a/entity/store.go
+++ b/entity/store.go
@@ -134,7 +134,7 @@ func (s *store) DeleteEntityLabel(entityType string, id string, label string) (e
 		ReturnNew: false,
 	}
 
-	var diff etre.Entity
+	diff := etre.Entity{}
 	// We call Select so that Apply will return the orginal deleted label (and
 	// "_id" field, which is included by default) rather than returning the
 	// entire original document
@@ -259,7 +259,7 @@ func (s *store) ReadEntities(entityType string, q query.Query) ([]etre.Entity, e
 
 	mgoQuery := translateQuery(q)
 
-	var entities []etre.Entity
+	entities := []etre.Entity{}
 	err = c.Find(mgoQuery).All(&entities)
 	if err != nil {
 		return nil, ErrRead{DbError: err}

--- a/entity/store_test.go
+++ b/entity/store_test.go
@@ -310,7 +310,7 @@ func TestReadEntitiesNotFound(t *testing.T) {
 	}
 	actual, err := es.ReadEntities(entityType, q)
 
-	if actual != nil {
+	if len(actual) != 0 {
 		t.Errorf("An empty list was expected, actual: %v", actual)
 	}
 	if err != nil {


### PR DESCRIPTION
* api should return empty slices instead of nil when queries don't return any results
* entity_client.Update should only take one patch, not a slice of patches. the single patch is applied to everything that is matched by the query