### PR TITLE
v0.9: New WriteResult and handle dupe key errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,137 +2,185 @@
 
 
 [[projects]]
+  digest = "1:d867dfa6751c8d7a435821ad3b736310c2ed68945d05b50fb9d23aee0540c8cc"
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
+  pruneopts = "UT"
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
   version = "v1.0.6"
 
 [[projects]]
   branch = "master"
+  digest = "1:300c0d22047b2fa7c4a9cd4c9cc2ca5a6e941fdcd320c54a54626dbfb86d2a5f"
   name = "github.com/alexflint/go-arg"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f7c0423bd11ee80ab81d25c6d46f492998af8547"
 
 [[projects]]
   branch = "master"
+  digest = "1:e36bd4aac23f7b8cafe074ed789b89d673f88d14443a230d3982a694704d121b"
   name = "github.com/alexflint/go-scalar"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e80c3b7ed292b052c7083b6fd7154a8422c33f65"
 
 [[projects]]
+  digest = "1:76dc72490af7174349349838f2fe118996381b31ea83243812a97e5a0fd5ed55"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = "UT"
   revision = "06ea1031745cb8b3dab3f6a236daf2b0aa468b7e"
   version = "v3.2.0"
 
 [[projects]]
-  branch = "master"
+  digest = "1:4b08116de0de75c041bb341686f0b139930f26cb84dfdf7641d435548114181d"
   name = "github.com/globalsign/mgo"
   packages = [
     ".",
     "bson",
     "internal/json",
     "internal/sasl",
-    "internal/scram"
+    "internal/scram",
   ]
+  pruneopts = "UT"
   revision = "113d3961e7311526535a1ef7042196563d442761"
+  version = "r2018.06.15"
 
 [[projects]]
+  digest = "1:7f89e0c888fb99c61055c646f5678aae645b0b0a1443d9b2dcd9964d850827ce"
   name = "github.com/go-test/deep"
   packages = ["."]
+  pruneopts = "UT"
   revision = "6592d9cc0a499ad2d5f574fde80a2b5c5cc3b4f5"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3fb07f8e222402962fa190eb060608b34eddfb64562a18e2167df2de0ece85d8"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
+  pruneopts = "UT"
   revision = "24b0969c4cb722950103eed87108c8d291a8df00"
 
 [[projects]]
+  digest = "1:43dd08a10854b2056e615d1b1d22ac94559d822e1f8b6fcc92c1a1057e85188e"
   name = "github.com/gorilla/websocket"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:87f801436ec4799e0e043ab348ff9f3e95b1b3761138158f0950ac67695cc272"
   name = "github.com/labstack/echo"
   packages = [
     ".",
-    "middleware"
+    "middleware",
   ]
+  pruneopts = "UT"
   revision = "6d227dfea4d2e52cb76856120b3c17f758139b4e"
   version = "3.3.5"
 
 [[projects]]
+  digest = "1:568171fc14a3d819b112c3e219d351ea7b05e8dad7935c4168c6b3373244a686"
   name = "github.com/labstack/gommon"
   packages = [
     "bytes",
     "color",
     "log",
-    "random"
+    "random",
   ]
+  pruneopts = "UT"
   revision = "d6898124de917583f5ff5592ef931d1dfe0ddc05"
   version = "0.2.6"
 
 [[projects]]
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = "UT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:757b110984b77e820e01c60d3ac03a376a0fdb05c990dd9d6bd4f9ba0d606261"
   name = "github.com/rs/xid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2c7e97ce663ff82c49656bca3048df0fdd83c5f9"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:c468422f334a6b46a19448ad59aaffdfc0a36b08fdcc1c749a0b29b6453d7e59"
   name = "github.com/valyala/bytebufferpool"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7"
 
 [[projects]]
   branch = "master"
+  digest = "1:268b8bce0064e8c057d7b913605459f9a26dcab864c0886a56d196540fbf003f"
   name = "github.com/valyala/fasttemplate"
   packages = ["."]
+  pruneopts = "UT"
   revision = "dcecefd839c4193db0d35b88ec65b4c12d360ab0"
 
 [[projects]]
   branch = "master"
+  digest = "1:72503e87c2b7e319cb7b676943915aa8d62b224831963dd5961624c0189daa00"
   name = "golang.org/x/crypto"
   packages = [
     "acme",
     "acme/autocert",
-    "ssh/terminal"
+    "ssh/terminal",
   ]
+  pruneopts = "UT"
   revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
+  digest = "1:be95d758fc4d9216e5d41ff5b98b46938fba85ca5bc2ddc45a1b03e2bb10fe7c"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "UT"
   revision = "e072cadbbdc8dd3d3ffa82b8b4b9304c261d9311"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "db591b90f1fed8f517cca6c453aa063438ea262669e4ca46a9462a03fab50e73"
+  input-imports = [
+    "github.com/Sirupsen/logrus",
+    "github.com/alexflint/go-arg",
+    "github.com/globalsign/mgo",
+    "github.com/globalsign/mgo/bson",
+    "github.com/go-test/deep",
+    "github.com/golang/groupcache/lru",
+    "github.com/gorilla/websocket",
+    "github.com/labstack/echo",
+    "github.com/labstack/echo/middleware",
+    "github.com/rs/xid",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/api.go
+++ b/api/api.go
@@ -21,11 +21,6 @@ import (
 	"github.com/labstack/echo"
 )
 
-var (
-	slugPattern   = `([\w-]+)`
-	labelsPattern = `([\w-_]+)`
-)
-
 // API provides controllers for endpoints it registers with a router.
 type API struct {
 	addr string
@@ -153,7 +148,9 @@ func (api *API) postEntitiesHandler(c echo.Context) error {
 		return handleError(err)
 	}
 
-	wo := writeOp(c)
+	wo, err := writeOp(c)
+	if err != nil {
+	}
 
 	// Get entities from request payload.
 	var entities []etre.Entity
@@ -172,10 +169,10 @@ func (api *API) postEntitiesHandler(c echo.Context) error {
 	}
 
 	ids, err := api.es.CreateEntities(wo, entities)
-	if ids == nil && err != nil {
+	wr := api.WriteResults(ids, err)
+	if err != nil {
 		return handleError(ErrDb.New(err.Error()))
 	}
-	wr := api.WriteResults(ids, err)
 
 	return c.JSON(http.StatusCreated, wr)
 }
@@ -497,6 +494,7 @@ func (api *API) WriteResults(v interface{}, err error) []etre.WriteResult {
 			}
 		}
 	} else if ids, ok := v.([]string); ok {
+		// Entity _id from CreateEntities
 		n := len(ids)
 		if err != nil {
 			n += 1

--- a/api/api.go
+++ b/api/api.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -23,23 +22,51 @@ import (
 
 // API provides controllers for endpoints it registers with a router.
 type API struct {
-	addr string
-	es   entity.Store
-	ff   cdc.FeedFactory
+	addr     string
+	validate entity.Validator
+	es       entity.Store
+	ff       cdc.FeedFactory
 	// --
 	echo *echo.Echo
 }
 
 // NewAPI makes a new API.
-func NewAPI(addr string, es entity.Store, ff cdc.FeedFactory) *API {
+func NewAPI(addr string, validate entity.Validator, es entity.Store, ff cdc.FeedFactory) *API {
 	api := &API{
-		addr: addr,
-		es:   es,
-		ff:   ff,
-		echo: echo.New(),
+		addr:     addr,
+		validate: validate,
+		es:       es,
+		ff:       ff,
+		echo:     echo.New(),
 	}
 
 	router := api.echo.Group(etre.API_ROOT)
+
+	// Called before every route/controller
+
+	// WriteOp
+	router.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// All routes with an :entity param query the db, so increment
+			// the "all" metric for them so this line is repeated in every
+			// controller. Also set t0 for measuring query latency.
+			method := c.Request().Method
+			entityType := c.Param("type")
+			if entityType == "" || method == "GET" || method == "OPTION" {
+				return next(c)
+			}
+			if c.Path() == etre.API_ROOT+"/query/:type" {
+				return next(c)
+			}
+			// "PUT", "POST", "DELETE"
+			wo := writeOp(c)
+			if err := api.validate.WriteOp(wo); err != nil {
+				return c.JSON(api.WriteResult(nil, err))
+			}
+			c.Set("wo", writeOp(c))
+			return next(c)
+		}
+	})
 
 	// /////////////////////////////////////////////////////////////////////
 	// Query
@@ -93,41 +120,39 @@ func (api *API) Router() *echo.Echo {
 	return api.echo
 }
 
-// /////////////////////////////////////////////////////////////////////////////
-// Controllers
-// /////////////////////////////////////////////////////////////////////////////
-
 // -----------------------------------------------------------------------------
 // Query
 // -----------------------------------------------------------------------------
 
 func (api *API) getEntitiesHandler(c echo.Context) error {
 	if err := validateParams(c, false); err != nil {
-		return handleError(err)
+		return readError(err)
 	}
 	entityType := c.Param("type")
+	if err := api.validate.EntityType(entityType); err != nil {
+		return readError(err)
+	}
 
 	// Translate URL query to query struct.
 	requestLabelSelector := c.QueryParam("query")
 	if requestLabelSelector == "" {
-		return handleError(ErrInvalidQuery.New("query string is empty"))
+		return readError(ErrInvalidQuery.New("query string is empty"))
 	}
-
 	q, err := query.Translate(requestLabelSelector)
 	if err != nil {
-		return handleError(ErrInvalidQuery.New("invalid query: %s", err))
+		return readError(ErrInvalidQuery.New("invalid query: %s", err))
 	}
 
 	// Query Filter
 	f := etre.QueryFilter{}
-	csvReturnLabels := c.QueryParam("labels")
-	if csvReturnLabels != "" {
-		f.ReturnLabels = strings.Split(csvReturnLabels, ",")
+	csv := c.QueryParam("labels")
+	if csv != "" {
+		f.ReturnLabels = strings.Split(csv, ",")
 	}
 
 	entities, err := api.es.ReadEntities(entityType, q, f)
 	if err != nil {
-		return handleError(ErrDb.New("database error: %s", err))
+		return readError(ErrDb.New("database error: %s", err))
 	}
 
 	return c.JSON(http.StatusOK, entities)
@@ -145,153 +170,122 @@ func (api *API) queryHandler(c echo.Context) error {
 
 func (api *API) postEntitiesHandler(c echo.Context) error {
 	if err := validateParams(c, false); err != nil {
-		return handleError(err)
+		return c.JSON(api.WriteResult(nil, err))
 	}
+	wo := c.Get("wo").(entity.WriteOp)
 
-	wo, err := writeOp(c)
-	if err != nil {
-	}
-
-	// Get entities from request payload.
 	var entities []etre.Entity
 	if err := c.Bind(&entities); err != nil {
-		return handleError(ErrInternal.New(err.Error()))
+		return c.JSON(api.WriteResult(nil, ErrInternal.New(err.Error())))
 	}
 
-	for _, e := range entities {
-		ConvertFloat64ToInt(e)
-		for k, v := range e {
-			if !validValueType(v) {
-				return handleError(ErrBadRequest.New("Key %v has value %v with invalid type: %v. "+
-					"Type of value must be a string or int.", k, v, reflect.TypeOf(v)))
-			}
-		}
+	if err := api.validate.Entities(entities, entity.VALIDATE_ON_CREATE); err != nil {
+		return c.JSON(api.WriteResult(nil, err))
 	}
 
 	ids, err := api.es.CreateEntities(wo, entities)
-	wr := api.WriteResults(ids, err)
-	if err != nil {
-		return handleError(ErrDb.New(err.Error()))
-	}
-
-	return c.JSON(http.StatusCreated, wr)
+	return c.JSON(api.WriteResult(ids, err))
 }
 
 func (api *API) putEntitiesHandler(c echo.Context) error {
 	if err := validateParams(c, false); err != nil {
-		return handleError(err)
+		return c.JSON(api.WriteResult(nil, err))
 	}
-
-	wo := writeOp(c)
 
 	// Translate URL query to query struct.
 	requestLabelSelector := c.QueryParam("query")
 	if requestLabelSelector == "" {
-		return handleError(ErrInvalidQuery.New("query string is empty"))
+		return c.JSON(api.WriteResult(nil, ErrInvalidQuery.New("query string is empty")))
 	}
 
 	q, err := query.Translate(requestLabelSelector)
 	if err != nil {
-		return handleError(ErrInvalidQuery.New("invalid query: %s", err))
+		return c.JSON(api.WriteResult(nil, ErrInvalidQuery.New("invalid query: %s", err)))
 	}
 
 	// Get entities from request payload.
-	var requestUpdate etre.Entity
-	if err := c.Bind(&requestUpdate); err != nil {
-		return handleError(ErrInternal.New(err.Error()))
+	var patch etre.Entity
+	if err := c.Bind(&patch); err != nil {
+		return c.JSON(api.WriteResult(nil, ErrInternal.New(err.Error())))
 	}
 
-	entities, err := api.es.UpdateEntities(wo, q, requestUpdate)
-	if entities == nil && err != nil {
-		return handleError(ErrDb.New(err.Error()))
+	if err := api.validate.Entities([]etre.Entity{patch}, entity.VALIDATE_ON_UPDATE); err != nil {
+		return c.JSON(api.WriteResult(nil, err))
 	}
-	wr := api.WriteResults(entities, err)
 
-	return c.JSON(http.StatusOK, wr)
+	wo := c.Get("wo").(entity.WriteOp)
+	entities, err := api.es.UpdateEntities(wo, q, patch)
+	return c.JSON(api.WriteResult(entities, err))
 }
 
 func (api *API) deleteEntitiesHandler(c echo.Context) error {
 	if err := validateParams(c, false); err != nil {
-		return handleError(err)
+		return c.JSON(api.WriteResult(nil, err))
 	}
-
-	wo := writeOp(c)
 
 	// Translate URL query to query struct.
 	requestLabelSelector := c.QueryParam("query")
 	if requestLabelSelector == "" {
-		return handleError(ErrInvalidQuery.New("query string is empty"))
+		return c.JSON(api.WriteResult(nil, ErrInvalidQuery.New("query string is empty")))
 	}
 
 	q, err := query.Translate(requestLabelSelector)
 	if err != nil {
-		return handleError(ErrInvalidQuery.New("invalid query: %s", err))
+		return c.JSON(api.WriteResult(nil, ErrInvalidQuery.New("invalid query: %s", err)))
 	}
 
+	wo := c.Get("wo").(entity.WriteOp)
 	entities, err := api.es.DeleteEntities(wo, q)
-	if entities == nil && err != nil {
-		return handleError(ErrDb.New(err.Error()))
-	}
-	wr := api.WriteResults(entities, err)
-
-	return c.JSON(http.StatusOK, wr)
+	return c.JSON(api.WriteResult(entities, err))
 }
 
 // -----------------------------------------------------------------------------
 // Enitity
 // -----------------------------------------------------------------------------
 
+// Create one entity
 func (api *API) postEntityHandler(c echo.Context) error {
 	if err := validateParams(c, false); err != nil {
-		return handleError(err)
+		return c.JSON(api.WriteResult(nil, err))
+	}
+	wo := c.Get("wo").(entity.WriteOp)
+
+	var newEntity etre.Entity
+	if err := c.Bind(&newEntity); err != nil {
+		return c.JSON(api.WriteResult(nil, ErrInternal.New(err.Error())))
 	}
 
-	wo := writeOp(c)
-
-	// Get entity from request payload.
-	var entity etre.Entity
-	if err := c.Bind(&entity); err != nil {
-		return handleError(ErrInternal.New(err.Error()))
+	entities := []etre.Entity{newEntity}
+	if err := api.validate.Entities(entities, entity.VALIDATE_ON_CREATE); err != nil {
+		return c.JSON(api.WriteResult(nil, err))
 	}
 
-	ConvertFloat64ToInt(entity)
-	for k, v := range entity {
-		if !validValueType(v) {
-			return handleError(ErrBadRequest.New("Key %v has value %v with invalid type: %v. "+
-				"Type of value must be a string or int.", k, v, reflect.TypeOf(v)))
-		}
-	}
-
-	ids, err := api.es.CreateEntities(wo, []etre.Entity{entity})
-	if ids == nil && err != nil {
-		return handleError(ErrDb.New(err.Error()))
-	}
-	wr := api.WriteResults(ids, err)
-
-	return c.JSON(http.StatusCreated, wr[0])
+	ids, err := api.es.CreateEntities(wo, entities)
+	return c.JSON(api.WriteResult(ids, err))
 }
 
+// Get one entity by _id
 func (api *API) getEntityHandler(c echo.Context) error {
 	if err := validateParams(c, true); err != nil {
-		return handleError(err)
+		return readError(err)
 	}
 	entityType := c.Param("type")
 	entityId := c.Param("id")
-
-	q := queryForId(entityId)
+	if err := api.validate.EntityType(entityType); err != nil {
+		return readError(err)
+	}
 
 	// Query Filter
 	f := etre.QueryFilter{}
-	csvReturnLabels := c.QueryParam("labels")
-	if csvReturnLabels != "" {
-		f.ReturnLabels = strings.Split(csvReturnLabels, ",")
+	csv := c.QueryParam("labels")
+	if csv != "" {
+		f.ReturnLabels = strings.Split(csv, ",")
 	}
 
-	entities, err := api.es.ReadEntities(entityType, q, f)
+	entities, err := api.es.ReadEntities(entityType, query.IdEqual(entityId), f)
 	if err != nil {
-		return handleError(ErrDb.New(err.Error()))
+		return readError(ErrDb.New(err.Error()))
 	}
-
 	if len(entities) == 0 {
 		return c.JSON(http.StatusNotFound, nil)
 	}
@@ -299,72 +293,57 @@ func (api *API) getEntityHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, entities[0])
 }
 
+// Patch one entity by _id
 func (api *API) putEntityHandler(c echo.Context) error {
 	if err := validateParams(c, true); err != nil {
-		return handleError(err)
+		return c.JSON(api.WriteResult(nil, err))
+	}
+	wo := c.Get("wo").(entity.WriteOp)
+
+	var patch etre.Entity
+	if err := c.Bind(&patch); err != nil {
+		return c.JSON(api.WriteResult(nil, ErrInternal.New(err.Error())))
 	}
 
-	wo := writeOp(c)
-
-	// Get entities from request payload.
-	var requestUpdate etre.Entity
-	if err := c.Bind(&requestUpdate); err != nil {
-		return handleError(ErrInternal.New(err.Error()))
+	if err := api.validate.Entities([]etre.Entity{patch}, entity.VALIDATE_ON_UPDATE); err != nil {
+		return c.JSON(api.WriteResult(nil, err))
 	}
 
-	q := queryForId(wo.EntityId)
-
-	entities, err := api.es.UpdateEntities(wo, q, requestUpdate)
-	if entities == nil && err != nil {
-		return handleError(ErrDb.New(err.Error()))
-	}
-
-	if len(entities) == 0 {
+	entities, err := api.es.UpdateEntities(wo, query.IdEqual(wo.EntityId), patch)
+	if err == nil && len(entities) == 0 {
 		return c.JSON(http.StatusNotFound, nil)
 	}
-
-	wr := api.WriteResults(entities, err)
-
-	return c.JSON(http.StatusOK, wr[0])
+	return c.JSON(api.WriteResult(entities, err))
 }
 
+// Delete one entity by _id
 func (api *API) deleteEntityHandler(c echo.Context) error {
 	if err := validateParams(c, true); err != nil {
-		return handleError(err)
+		return c.JSON(api.WriteResult(nil, err))
 	}
-
-	wo := writeOp(c)
-
-	q := queryForId(wo.EntityId)
-
-	entities, err := api.es.DeleteEntities(wo, q)
-	if entities == nil && err != nil {
-		return handleError(ErrDb.New(err.Error()))
-	}
-
-	if len(entities) == 0 {
+	wo := c.Get("wo").(entity.WriteOp)
+	entities, err := api.es.DeleteEntities(wo, query.IdEqual(wo.EntityId))
+	if err == nil && len(entities) == 0 {
 		return c.JSON(http.StatusNotFound, nil)
 	}
-
-	wr := api.WriteResults(entities, err)
-
-	return c.JSON(http.StatusOK, wr[0])
+	return c.JSON(api.WriteResult(entities, err))
 }
 
-// Getting all labels for a single entity.
+// Get labels of entity by _id
 func (api *API) entityLabelsHandler(c echo.Context) error {
 	if err := validateParams(c, true); err != nil {
-		return handleError(err)
+		return readError(err)
 	}
 	entityType := c.Param("type")
 	entityId := c.Param("id")
-
-	q := queryForId(entityId)
-	entities, err := api.es.ReadEntities(entityType, q, etre.QueryFilter{})
-	if err != nil {
-		return handleError(ErrDb.New(err.Error()))
+	if err := api.validate.EntityType(entityType); err != nil {
+		return readError(err)
 	}
 
+	entities, err := api.es.ReadEntities(entityType, query.IdEqual(entityId), etre.QueryFilter{})
+	if err != nil {
+		return readError(ErrDb.New(err.Error()))
+	}
 	if len(entities) == 0 {
 		return c.JSON(http.StatusNotFound, nil)
 	}
@@ -372,42 +351,28 @@ func (api *API) entityLabelsHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, entities[0].Labels())
 }
 
-// Delete a label from a single entity.
+// Delete one label from one entity by _id
 func (api *API) entityDeleteLabelHandler(c echo.Context) error {
 	if err := validateParams(c, true); err != nil {
-		return handleError(err)
+		return c.JSON(api.WriteResult(nil, err))
 	}
+	wo := c.Get("wo").(entity.WriteOp)
 
 	label := c.Param("label")
 	if label == "" {
-		return ErrMissingParam.New("missing label param")
+		return c.JSON(api.WriteResult(nil, ErrMissingParam.New("missing label param")))
 	}
 
-	// Don't allow deleting metalabel
-	if etre.IsMetalabel(label) {
-		errResp := etre.Error{
-			Message:    "deleting metalabel " + label + " is not allowed",
-			Type:       "delete-metalabel",
-			HTTPStatus: http.StatusForbidden,
-		}
-		return c.JSON(http.StatusForbidden, errResp)
-
+	if err := api.validate.DeleteLabel(label); err != nil {
+		return c.JSON(api.WriteResult(nil, err))
 	}
-
-	wo := writeOp(c)
 
 	diff, err := api.es.DeleteLabel(wo, label)
-	if err != nil {
-		switch err {
-		case entity.ErrNotFound:
-			return c.JSON(http.StatusNotFound, nil)
-		default:
-			return handleError(ErrDb.New(err.Error()))
-		}
+	if err != nil && err == etre.ErrEntityNotFound {
+		return c.JSON(http.StatusNotFound, nil)
 	}
 
-	wr := api.WriteResults(diff, err)
-	return c.JSON(http.StatusOK, wr[0])
+	return c.JSON(api.WriteResult(diff, err))
 }
 
 // --------------------------------------------------------------------------
@@ -437,122 +402,142 @@ var upgrader = websocket.Upgrader{
 
 func (api *API) changesHandler(c echo.Context) error {
 	if api.ff == nil {
-		return handleError(ErrCDCDisabled)
+		return readError(ErrCDCDisabled)
 	}
 
 	// Upgrade to a WebSocket connection.
 	wsConn, err := upgrader.Upgrade(c.Response(), c.Request(), nil)
 	if err != nil {
-		return handleError(ErrInternal.New(err.Error()))
+		return readError(ErrInternal.New(err.Error()))
 	}
 
 	// Create and run a feed.
 	f := api.ff.MakeWebsocket(wsConn)
 	if err := f.Run(); err != nil {
-		return handleError(ErrInternal.New(err.Error()))
+		return readError(ErrInternal.New(err.Error()))
 	}
 
 	return nil
 }
 
-// //////////////////////////////////////////////////////////////////////////
-// Helper funcs
-// //////////////////////////////////////////////////////////////////////////
-
-// WriteResults makes a slice of etre.WriteResult for each item in v, which
-// is either []string{<ids>} on POST/create or []etre.Entity{} on PUT/update
-// and DELETE/delete. If err is not nil, it's the first (last and only)
-// error on write which applies to the last WriteResult in the returned slice.
-// The caller must handle this case:
-//
-//   if v == nil && err != nil {
-//
-// In that case, no writes were attempted, presumably because of a low-level db
-// issue (e.g. db is offiline). In other words: v most not be nil.
-func (api *API) WriteResults(v interface{}, err error) []etre.WriteResult {
-	var wr []etre.WriteResult
-	if diffs, ok := v.([]etre.Entity); ok {
-		n := len(diffs)
-		if err != nil {
-			n += 1
+// Return error on read. Writes always return an etre.WriteResult by calling WriteResult.
+func readError(err error) *echo.HTTPError {
+	switch v := err.(type) {
+	case etre.Error:
+		return echo.NewHTTPError(v.HTTPStatus, err)
+	case entity.ValidationError:
+		etreError := etre.Error{
+			Message:    v.Err.Error(),
+			Type:       v.Type,
+			HTTPStatus: http.StatusBadRequest,
 		}
-		wr = make([]etre.WriteResult, n)
-		for i, diff := range diffs {
-			// _id from db is a bson.ObjectId, which we need to encode
-			// as a hex string.
-			id := hex.EncodeToString([]byte(diff["_id"].(bson.ObjectId)))
+		return echo.NewHTTPError(etreError.HTTPStatus, etreError)
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, err)
+	}
+}
 
-			wr[i] = etre.WriteResult{
+// Return an etre.WriteResult for all writes, successful of not. v are the writes,
+// if any, from entity.Store calls, which is why it can be different types.
+// v and err are _not_ mutually exclusive; writes can be partially successful.
+func (api *API) WriteResult(v interface{}, err error) (int, etre.WriteResult) {
+	var httpStatus = http.StatusInternalServerError
+	var wr etre.WriteResult
+	var writes []etre.Write
+
+	// Map error to etre.Error
+	if err != nil {
+		switch err.(type) {
+		case etre.Error:
+			v := err.(etre.Error)
+			wr.Error = &v
+		case entity.ValidationError:
+			v := err.(entity.ValidationError)
+			wr.Error = &etre.Error{
+				Message:    v.Err.Error(),
+				Type:       v.Type,
+				HTTPStatus: http.StatusBadRequest,
+			}
+		case entity.DbError:
+			v := err.(entity.DbError)
+			wr.Error = &etre.Error{
+				Message:    v.Err.Error(),
+				Type:       v.Type,
+				HTTPStatus: http.StatusInternalServerError,
+			}
+		default:
+			wr.Error = &etre.Error{
+				Message:    err.Error(),
+				Type:       "unhandled-error",
+				HTTPStatus: http.StatusInternalServerError,
+			}
+		}
+		httpStatus = wr.Error.HTTPStatus
+	} else {
+		httpStatus = http.StatusOK
+	}
+
+	// No writes, probably error before call to entity.Store
+	if v == nil {
+		return httpStatus, wr
+	}
+
+	// Map writes to WriteResult.Writes: []etre.Write
+	switch v.(type) {
+	case []etre.Entity:
+		// Diffs from UpdateEntities and DeleteEntities
+		diffs := v.([]etre.Entity)
+		writes = make([]etre.Write, len(diffs))
+		for i, diff := range diffs {
+			// _id from db is bson.ObjectId, convert to string
+			id := hex.EncodeToString([]byte(diff["_id"].(bson.ObjectId)))
+			writes[i] = etre.Write{
 				Id:   id,
 				URI:  api.addr + etre.API_ROOT + "/entity/" + id,
 				Diff: diff,
 			}
 		}
-		if err != nil {
-			wr[len(wr)-1] = etre.WriteResult{
-				Error: err.Error(),
-			}
-		}
-	} else if ids, ok := v.([]string); ok {
+	case []string:
 		// Entity _id from CreateEntities
-		n := len(ids)
-		if err != nil {
-			n += 1
-		}
-		wr = make([]etre.WriteResult, n)
+		ids := v.([]string)
+		writes = make([]etre.Write, len(ids))
 		for i, id := range ids {
-			wr[i] = etre.WriteResult{
+			writes[i] = etre.Write{
 				Id:  id,
 				URI: api.addr + etre.API_ROOT + "/entity/" + id,
 			}
 		}
-		if err != nil {
-			wr[len(wr)-1] = etre.WriteResult{
-				Error: err.Error(),
-			}
-		}
-	} else if diff, ok := v.(etre.Entity); ok {
-		wr = make([]etre.WriteResult, 1)
+		httpStatus = http.StatusCreated
+	case etre.Entity:
+		// Entity from DeleteLabel
+		diff := v.(etre.Entity)
+		// _id from db is bson.ObjectId, convert to string
 		id := hex.EncodeToString([]byte(diff["_id"].(bson.ObjectId)))
-		wr[0] = etre.WriteResult{
-			Id:   id,
-			URI:  api.addr + etre.API_ROOT + "/entity/" + id,
-			Diff: diff,
+		writes = []etre.Write{
+			{
+				Id:   id,
+				URI:  api.addr + etre.API_ROOT + "/entity/" + id,
+				Diff: diff,
+			},
 		}
-		if err != nil {
-			wr[0] = etre.WriteResult{
-				Error: err.Error(),
-			}
-		}
-	} else {
-		msg := fmt.Sprintf("api.WriteResults: invalid arg v: %v, expected []etre.Entity or []string",
-			reflect.TypeOf(v))
+	default:
+		msg := fmt.Sprintf("api.WriteResult: invalid arg type: %#v", v)
 		panic(msg)
 	}
-	return wr
+	wr.Writes = writes
+	return httpStatus, wr
 }
-
-// JSON treats all numbers as floats. Given this, when we see a float with
-// decimal values of all 0, it is unclear if the user passed in 3.0 (type
-// float) or 3 (type int). So, since we cannot tell the difference between a
-// some float numbers and integer numbers, we cast all floats to ints. This
-// means that floats with non-zero decimal values, such as 3.14 (type float),
-// will get truncated to 3i (type int) in this case.
-func ConvertFloat64ToInt(entity etre.Entity) {
-	for k, v := range entity {
-		if reflect.TypeOf(v).Kind() == reflect.Float64 {
-			entity[k] = int(v.(float64))
-		}
-	}
-}
-
-// //////////////////////////////////////////////////////////////////////////
-// Private funcs
-// //////////////////////////////////////////////////////////////////////////
 
 func writeOp(c echo.Context) entity.WriteOp {
+	username := "?"
+	if val := c.Get("username"); val != nil {
+		if u, ok := val.(string); ok {
+			username = u
+		}
+	}
+
 	wo := entity.WriteOp{
-		User:       getUsername(c),
+		User:       username,
 		EntityType: c.Param("type"),
 		EntityId:   c.Param("id"),
 	}
@@ -574,62 +559,19 @@ func writeOp(c echo.Context) entity.WriteOp {
 	return wo
 }
 
-// _id is not a valid field name to pass to query.Translate, so we manually
-// create a query object.
-func queryForId(id string) query.Query {
-	return query.Query{
-		Predicates: []query.Predicate{
-			query.Predicate{
-				Label:    "_id",
-				Operator: "=",
-				Value:    bson.ObjectIdHex(id),
-			},
-		},
-	}
-}
-
-// Values in entity must be of type string or int. This is because the query
-// language we use only supports querying by string or int. See more at:
-// github.com/square/etre/query
-func validValueType(v interface{}) bool {
-	k := reflect.TypeOf(v).Kind()
-	return k == reflect.String || k == reflect.Int || k == reflect.Bool
-}
-
 func validateParams(c echo.Context, needEntityId bool) error {
 	if c.Param("type") == "" {
 		return ErrMissingParam.New("missing type param")
 	}
-
-	if needEntityId {
-		id := c.Param("id")
-		if id == "" {
-			return ErrMissingParam.New("missing id param")
-		}
-
-		if !bson.IsObjectIdHex(id) {
-			return ErrInvalidParam.New("id %s is not a valid bson.ObjectId", id)
-		}
+	if !needEntityId {
+		return nil
 	}
-
+	id := c.Param("id")
+	if id == "" {
+		return ErrMissingParam.New("missing id param")
+	}
+	if !bson.IsObjectIdHex(id) {
+		return ErrInvalidParam.New("id %s is not a valid bson.ObjectId", id)
+	}
 	return nil
-}
-
-func getUsername(c echo.Context) string {
-	username := "?"
-	if val := c.Get("username"); val != nil {
-		if u, ok := val.(string); ok {
-			username = u
-		}
-	}
-	return username
-}
-
-func handleError(err error) *echo.HTTPError {
-	switch v := err.(type) {
-	case etre.Error:
-		return echo.NewHTTPError(v.HTTPStatus, err)
-	default:
-		return echo.NewHTTPError(http.StatusInternalServerError, err)
-	}
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -652,8 +652,8 @@ func TestGetEntitiesHandlerMissingQueryError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if statusCode != api.ErrBadRequest.HTTPStatus {
-		t.Errorf("response status = %d, expected %d", statusCode, api.ErrBadRequest.HTTPStatus)
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
 	}
 	if respErr.Type != api.ErrInvalidQuery.Type {
 		t.Errorf("got error type %s, expected %s", respErr.Type, api.ErrInvalidQuery.Type)
@@ -665,8 +665,8 @@ func TestGetEntitiesHandlerMissingQueryError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if statusCode != api.ErrBadRequest.HTTPStatus {
-		t.Errorf("response status = %d, expected %d", statusCode, api.ErrBadRequest.HTTPStatus)
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
 	}
 	if respErr.Type != api.ErrInvalidQuery.Type {
 		t.Errorf("got error type %s, expected %s", respErr.Type, api.ErrInvalidQuery.Type)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
+	"github.com/square/etre/config"
 	"github.com/square/etre/entity"
 	"github.com/square/etre/query"
 	"github.com/square/etre/test"
@@ -45,6 +46,7 @@ var (
 var addr = "http://localhost"
 var entityType = "nodes"
 var validate = entity.NewValidator([]string{entityType})
+var cfg config.Config
 
 var es *mock.EntityStore
 var defaultServer *httptest.Server
@@ -71,7 +73,12 @@ func setup(t *testing.T) {
 				return deleteLabelEntity, nil
 			},
 		}
-		defaultAPI := api.NewAPI(addr, validate, es, &mock.FeedFactory{})
+		cfg = config.Config{
+			Server: config.ServerConfig{
+				Addr: addr,
+			},
+		}
+		defaultAPI := api.NewAPI(cfg, validate, es, &mock.FeedFactory{})
 		defaultServer = httptest.NewServer(defaultAPI)
 		t.Logf("started test HTTP server: %s\n", defaultServer.URL)
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -43,6 +44,7 @@ var (
 
 var addr = "http://localhost"
 var entityType = "nodes"
+var validate = entity.NewValidator([]string{entityType})
 
 var es *mock.EntityStore
 var defaultServer *httptest.Server
@@ -69,7 +71,7 @@ func setup(t *testing.T) {
 				return deleteLabelEntity, nil
 			},
 		}
-		defaultAPI := api.NewAPI(addr, es, &mock.FeedFactory{})
+		defaultAPI := api.NewAPI(addr, validate, es, &mock.FeedFactory{})
 		defaultServer = httptest.NewServer(defaultAPI)
 		t.Logf("started test HTTP server: %s\n", defaultServer.URL)
 	}
@@ -98,6 +100,16 @@ func setup(t *testing.T) {
 func teardown(t *testing.T) {
 }
 
+func floatToInt(entities []etre.Entity) {
+	for i, e := range entities {
+		for label, val := range e {
+			if reflect.TypeOf(val).Kind() == reflect.Float64 {
+				entities[i][label] = int(val.(float64))
+			}
+		}
+	}
+}
+
 // //////////////////////////////////////////////////////////////////////////
 // Single Entity Management Handler Tests
 // //////////////////////////////////////////////////////////////////////////
@@ -122,17 +134,19 @@ func TestPostEntityHandlerSuccessful(t *testing.T) {
 	}
 
 	if statusCode != http.StatusCreated {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
+		t.Errorf("response status = %d, expected %d", statusCode, http.StatusCreated)
 	}
 
-	if actual.Id != "id1" {
-		t.Errorf("WriteResult.Id = %s, expected id1", actual.Id)
-	}
 	expect := etre.WriteResult{
-		Id:  actual.Id,
-		URI: addr + etre.API_ROOT + "/entity/" + actual.Id,
+		Writes: []etre.Write{
+			{
+				Id:  "id1",
+				URI: addr + etre.API_ROOT + "/entity/id1",
+			},
+		},
 	}
 	if diffs := deep.Equal(actual, expect); diffs != nil {
+		t.Logf("%+v", actual.Error)
 		t.Error(diffs)
 	}
 }
@@ -145,21 +159,25 @@ func TestPostEntityHandlerPayloadError(t *testing.T) {
 	// etre.Entity type is expected to be in the payload, so passing in an empty
 	// payload will trigger an error.
 	var payload []byte
-	var respErr etre.Error
+	// Writes always return an etre.WriteResult, even on error
+	var respErr etre.WriteResult
 
 	statusCode, err := test.MakeHTTPRequest("POST", url, payload, &respErr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if statusCode != http.StatusInternalServerError {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusInternalServerError)
+	if statusCode != api.ErrInternal.HTTPStatus {
+		t.Errorf("response status = %d, expected %d", statusCode, api.ErrInternal.HTTPStatus)
 	}
 
-	if respErr.Type != "internal-error" {
-		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Type)
+	if respErr.Error == nil {
+		t.Fatalf("WriteResult.Error is nil, expected it to be set")
 	}
-	if respErr.Message == "" {
+	if respErr.Error.Type != api.ErrInternal.Type {
+		t.Errorf("got Error.Type = %s, expected %s", respErr.Error.Type, api.ErrInternal.Type)
+	}
+	if respErr.Error.Message == "" {
 		t.Errorf("Error.Message is empty, expected a value")
 	}
 }
@@ -178,7 +196,7 @@ func TestPostEntityHandlerInvalidValueTypeError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var respErr etre.Error
+	var respErr etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("POST", url, payload, &respErr)
 	if err != nil {
 		t.Fatal(err)
@@ -188,10 +206,13 @@ func TestPostEntityHandlerInvalidValueTypeError(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
 	}
 
-	if respErr.Type != "bad-request" {
-		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Type)
+	if respErr.Error == nil {
+		t.Fatalf("WriteResult.Error is nil, expected it to be set")
 	}
-	if respErr.Message == "" {
+	if respErr.Error.Type != "invalid-value-type" {
+		t.Errorf("got Error.Type = %s, expected invalid-value-type", respErr.Error.Type)
+	}
+	if respErr.Error.Message == "" {
 		t.Errorf("Error.Message is empty, expected a value")
 	}
 }
@@ -208,9 +229,11 @@ func TestGetEntityHandlerSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	api.ConvertFloat64ToInt(actual)
-
-	if diffs := deep.Equal(actual, seedEntities[0]); diffs != nil {
+	if len(actual) == 0 {
+		t.Fatal("did not return an entity")
+	}
+	floatToInt([]etre.Entity{actual})
+	if diffs := deep.Equal(actual, seedEntity0); diffs != nil {
 		t.Logf("got: %#v", actual)
 		t.Error(diffs)
 	}
@@ -301,18 +324,18 @@ func TestPutEntityHandlerSuccessful(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
 
-	if actual.Id != seedId0 {
-		t.Errorf("got id %s, expected %s", actual.Id, seedId0)
-	}
-	expectURI := addr + etre.API_ROOT + "/entity/" + actual.Id
-	if actual.URI != expectURI {
-		t.Errorf("got URI %s, expected %s", actual.URI, expectURI)
-	}
-	if actual.Diff == nil {
-		t.Fatal("got nil Diff, expected non-nil value")
-	}
 	updateEntities[0]["_id"] = seedId0 // convert back to string
-	if diffs := deep.Equal(actual.Diff, updateEntities[0]); diffs != nil {
+
+	expect := etre.WriteResult{
+		Writes: []etre.Write{
+			{
+				Id:   seedId0,
+				URI:  addr + etre.API_ROOT + "/entity/" + seedId0,
+				Diff: updateEntities[0],
+			},
+		},
+	}
+	if diffs := deep.Equal(actual, expect); diffs != nil {
 		t.Error(diffs)
 	}
 }
@@ -324,7 +347,7 @@ func TestPutEntityHandlerMissingIDError(t *testing.T) {
 	// Omit ID from URL
 	url := defaultServer.URL + etre.API_ROOT + "/entity/" + entityType + "/"
 
-	var respErr etre.Error
+	var respErr etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("PUT", url, nil, &respErr)
 	if err != nil {
 		t.Fatal(err)
@@ -348,7 +371,7 @@ func TestPutEntityHandlerPayloadError(t *testing.T) {
 	// etre.Entity type is expected to be in the payload, so passing in an empty
 	// payload will trigger an error.
 	var payload []byte
-	var respErr etre.Error
+	var respErr etre.WriteResult
 
 	statusCode, err := test.MakeHTTPRequest("PUT", url, payload, &respErr)
 	if err != nil {
@@ -359,10 +382,13 @@ func TestPutEntityHandlerPayloadError(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusInternalServerError)
 	}
 
-	if respErr.Type != "internal-error" {
-		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Type)
+	if respErr.Error == nil {
+		t.Fatalf("WriteResult.Error is nil, expected it to be set")
 	}
-	if respErr.Message == "" {
+	if respErr.Error.Type != "internal-error" {
+		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Error.Type)
+	}
+	if respErr.Error.Message == "" {
 		t.Errorf("Error.Message is empty, expected a value")
 	}
 }
@@ -391,9 +417,13 @@ func TestDeleteEntityHandlerSuccessful(t *testing.T) {
 	deleteEntities[0]["_id"] = seedId0 // convert back to string
 
 	expect := etre.WriteResult{
-		Id:   seedId0,
-		URI:  addr + etre.API_ROOT + "/entity/" + seedId0,
-		Diff: deleteEntities[0],
+		Writes: []etre.Write{
+			{
+				Id:   seedId0,
+				URI:  addr + etre.API_ROOT + "/entity/" + seedId0,
+				Diff: deleteEntities[0],
+			},
+		},
 	}
 	if diffs := deep.Equal(actual, expect); diffs != nil {
 		t.Logf("got: %#v", actual)
@@ -409,7 +439,7 @@ func TestDeleteEntityHandlerMissingIDError(t *testing.T) {
 	// Omit ID from URL
 	url := defaultServer.URL + etre.API_ROOT + "/entity/" + entityType + "/"
 
-	var respErr etre.Error
+	var respErr etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("DELETE", url, nil, &respErr)
 	if err != nil {
 		t.Fatal(err)
@@ -441,7 +471,7 @@ func TestPostEntitiesHandlerSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var actual []etre.WriteResult
+	var actual etre.WriteResult
 	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType
 
 	statusCode, err := test.MakeHTTPRequest("POST", url, payload, &actual)
@@ -453,10 +483,10 @@ func TestPostEntitiesHandlerSuccessful(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
 
-	if len(actual) != len(seedEntities) {
-		t.Errorf("got %d ids, expected %d", len(actual), len(seedEntities))
+	if len(actual.Writes) != len(seedEntities) {
+		t.Errorf("got %d ids, expected %d", len(actual.Writes), len(seedEntities))
 	}
-	for i, wr := range actual {
+	for i, wr := range actual.Writes {
 		if wr.Id != createIds[i] {
 			t.Errorf("WriteResult.Id = %s, expected %s", wr.Id, createIds[i])
 		}
@@ -465,9 +495,6 @@ func TestPostEntitiesHandlerSuccessful(t *testing.T) {
 		}
 		if wr.Diff != nil {
 			t.Errorf("WriteResult.Diff is set: %#v", wr)
-		}
-		if wr.Error != "" {
-			t.Errorf("WriteResult.Error is set: %#v", wr)
 		}
 	}
 }
@@ -480,7 +507,7 @@ func TestPostEntitiesHandlerPayloadError(t *testing.T) {
 	// etre.Entity type is expected to be in the payload, so passing in an empty
 	// payload will trigger an error.
 	var payload []byte
-	var respErr etre.Error
+	var respErr etre.WriteResult
 
 	statusCode, err := test.MakeHTTPRequest("POST", url, payload, &respErr)
 	if err != nil {
@@ -491,10 +518,13 @@ func TestPostEntitiesHandlerPayloadError(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusInternalServerError)
 	}
 
-	if respErr.Type != "internal-error" {
-		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Type)
+	if respErr.Error == nil {
+		t.Fatalf("WriteResult.Error is nil, expected it to be set")
 	}
-	if respErr.Message == "" {
+	if respErr.Error.Type != "internal-error" {
+		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Error.Type)
+	}
+	if respErr.Error.Message == "" {
 		t.Errorf("Error.Message is empty, expected a value")
 	}
 }
@@ -515,7 +545,7 @@ func TestPostEntitiesHandlerInvalidValueTypeError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var respErr etre.Error
+	var respErr etre.WriteResult
 
 	statusCode, err := test.MakeHTTPRequest("POST", url, payload, &respErr)
 	if err != nil {
@@ -526,10 +556,13 @@ func TestPostEntitiesHandlerInvalidValueTypeError(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
 	}
 
-	if respErr.Type != "bad-request" {
-		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Type)
+	if respErr.Error == nil {
+		t.Fatalf("WriteResult.Error is nil, expected it to be set")
 	}
-	if respErr.Message == "" {
+	if respErr.Error.Type != "invalid-value-type" {
+		t.Errorf("got Error.Type = %s, expected invalid-value-type", respErr.Error.Type)
+	}
+	if respErr.Error.Message == "" {
 		t.Errorf("Error.Message is empty, expected a value")
 	}
 }
@@ -549,8 +582,8 @@ func TestGetEntitiesHandlerSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	floatToInt(actual)
 	for _, e := range actual {
-		api.ConvertFloat64ToInt(e)
 		delete(e, "_id")
 		delete(e, "_rev")
 		delete(e, "_type")
@@ -571,19 +604,31 @@ func TestGetEntitiesHandlerMissingQueryError(t *testing.T) {
 
 	// Omit query param from URL
 	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?"
-	expectErr := "query string is empty"
-	testBadRequestError(t, "DELETE", url, expectErr)
-}
 
-func TestGetEntitiesHandlerEmptyQueryError(t *testing.T) {
-	setup(t)
-	defer teardown(t)
+	var respErr etre.Error
+	statusCode, err := test.MakeHTTPRequest("GET", url, nil, &respErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusCode != api.ErrBadRequest.HTTPStatus {
+		t.Errorf("response status = %d, expected %d", statusCode, api.ErrBadRequest.HTTPStatus)
+	}
+	if respErr.Type != api.ErrInvalidQuery.Type {
+		t.Errorf("got error type %s, expected %s", respErr.Type, api.ErrInvalidQuery.Type)
+	}
 
-	// Omit query string from URL
-	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?query"
-
-	expectErr := "query string is empty"
-	testBadRequestError(t, "GET", url, expectErr)
+	// Empty query
+	url = defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?query"
+	statusCode, err = test.MakeHTTPRequest("GET", url, nil, &respErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusCode != api.ErrBadRequest.HTTPStatus {
+		t.Errorf("response status = %d, expected %d", statusCode, api.ErrBadRequest.HTTPStatus)
+	}
+	if respErr.Type != api.ErrInvalidQuery.Type {
+		t.Errorf("got error type %s, expected %s", respErr.Type, api.ErrInvalidQuery.Type)
+	}
 }
 
 func TestGetEntitiesHandlerNotFoundError(t *testing.T) {
@@ -626,7 +671,7 @@ func TestPutEntitiesHandlerSuccessful(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var actual []etre.WriteResult
+	var actual etre.WriteResult
 	query := url.QueryEscape("x>0") // doesn't matter
 	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?query=" + query
 
@@ -639,24 +684,26 @@ func TestPutEntitiesHandlerSuccessful(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
 
-	if len(actual) != 2 {
-		t.Errorf("got %d WriteResult, expected 2", len(actual))
+	if len(actual.Writes) != 2 {
+		t.Errorf("got %d WriteResult, expected 2", len(actual.Writes))
 	}
 
 	// Convert back to string
 	updateEntities[0]["_id"] = seedId0
 	updateEntities[1]["_id"] = seedId1
 
-	expect := []etre.WriteResult{
-		{
-			Id:   seedId0,
-			URI:  addr + etre.API_ROOT + "/entity/" + seedId0,
-			Diff: updateEntities[0],
-		},
-		{
-			Id:   seedId1,
-			URI:  addr + etre.API_ROOT + "/entity/" + seedId1,
-			Diff: updateEntities[1],
+	expect := etre.WriteResult{
+		Writes: []etre.Write{
+			{
+				Id:   seedId0,
+				URI:  addr + etre.API_ROOT + "/entity/" + seedId0,
+				Diff: updateEntities[0],
+			},
+			{
+				Id:   seedId1,
+				URI:  addr + etre.API_ROOT + "/entity/" + seedId1,
+				Diff: updateEntities[1],
+			},
 		},
 	}
 	if diffs := deep.Equal(actual, expect); diffs != nil {
@@ -668,20 +715,39 @@ func TestPutEntitiesHandlerMissingQueryError(t *testing.T) {
 	setup(t)
 	defer teardown(t)
 
+	var respErr etre.WriteResult
+
 	// Omit query param from URL
 	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?"
-	expectErr := "query string is empty"
-	testBadRequestError(t, "DELETE", url, expectErr)
-}
+	statusCode, err := test.MakeHTTPRequest("PUT", url, nil, &respErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusCode != http.StatusBadRequest {
+		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
+	}
+	if respErr.Error == nil {
+		t.Fatal("WriteResult.Error is nil, expected it to be set")
+	}
+	if respErr.Error.Type != api.ErrInvalidQuery.Type {
+		t.Errorf("got error type %s, expected %s", respErr.Error.Type, api.ErrInvalidQuery.Type)
+	}
 
-func TestPutEntitiesHandlerEmptyQueryError(t *testing.T) {
-	setup(t)
-	defer teardown(t)
-
-	// Omit query string from URL
-	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?query"
-	expectErr := "query string is empty"
-	testBadRequestError(t, "PUT", url, expectErr)
+	// Empty query
+	url = defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?query"
+	statusCode, err = test.MakeHTTPRequest("PUT", url, nil, &respErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusCode != api.ErrInvalidQuery.HTTPStatus {
+		t.Errorf("response status = %d, expected %d", statusCode, api.ErrInvalidQuery.HTTPStatus)
+	}
+	if respErr.Error == nil {
+		t.Fatal("WriteResult.Error is nil, expected it to be set")
+	}
+	if respErr.Error.Type != api.ErrInvalidQuery.Type {
+		t.Errorf("got error type %s, expected %s", respErr.Error.Type, api.ErrInvalidQuery.Type)
+	}
 }
 
 func TestPutEntitiesHandlerPayloadError(t *testing.T) {
@@ -694,7 +760,7 @@ func TestPutEntitiesHandlerPayloadError(t *testing.T) {
 	// etre.Entity type is expected to be in the payload, so passing in an empty
 	// payload will trigger an error.
 	var payload []byte
-	var respErr etre.Error
+	var respErr etre.WriteResult
 
 	statusCode, err := test.MakeHTTPRequest("PUT", url, payload, &respErr)
 	if err != nil {
@@ -705,10 +771,13 @@ func TestPutEntitiesHandlerPayloadError(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusInternalServerError)
 	}
 
-	if respErr.Type != "internal-error" {
-		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Type)
+	if respErr.Error == nil {
+		t.Fatalf("WriteResult.Error is nil, expected it to be set")
 	}
-	if respErr.Message == "" {
+	if respErr.Error.Type != "internal-error" {
+		t.Errorf("got Error.Type = %s, expected internal-error", respErr.Error.Type)
+	}
+	if respErr.Error.Message == "" {
 		t.Errorf("Error.Message is empty, expected a value")
 	}
 }
@@ -724,7 +793,7 @@ func TestDeleteEntitiesHandlerSuccessful(t *testing.T) {
 
 	query := url.QueryEscape("foo=bar") // doesn't matter
 	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?query=" + query
-	var actual []etre.WriteResult
+	var actual etre.WriteResult
 
 	statusCode, err := test.MakeHTTPRequest("DELETE", url, nil, &actual)
 	if err != nil {
@@ -735,24 +804,22 @@ func TestDeleteEntitiesHandlerSuccessful(t *testing.T) {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
 
-	if len(actual) != 2 {
-		t.Errorf("got %d WriteResult, expected 2", len(actual))
-	}
-
 	// Convert back to string
 	deleteEntities[0]["_id"] = seedId0
 	deleteEntities[1]["_id"] = seedId1
 
-	expect := []etre.WriteResult{
-		{
-			Id:   seedId0,
-			URI:  addr + etre.API_ROOT + "/entity/" + seedId0,
-			Diff: deleteEntities[0],
-		},
-		{
-			Id:   seedId1,
-			URI:  addr + etre.API_ROOT + "/entity/" + seedId1,
-			Diff: deleteEntities[1],
+	expect := etre.WriteResult{
+		Writes: []etre.Write{
+			{
+				Id:   seedId0,
+				URI:  addr + etre.API_ROOT + "/entity/" + seedId0,
+				Diff: deleteEntities[0],
+			},
+			{
+				Id:   seedId1,
+				URI:  addr + etre.API_ROOT + "/entity/" + seedId1,
+				Diff: deleteEntities[1],
+			},
 		},
 	}
 	if diffs := deep.Equal(actual, expect); diffs != nil {
@@ -764,20 +831,36 @@ func TestDeleteEntitiesHandlerMissingQueryError(t *testing.T) {
 	setup(t)
 	defer teardown(t)
 
+	var respErr etre.WriteResult
+
 	// Omit query param from URL
 	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType + "?"
-	expectErr := "query string is empty"
-	testBadRequestError(t, "DELETE", url, expectErr)
-}
+	statusCode, err := test.MakeHTTPRequest("DELETE", url, nil, &respErr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if statusCode != api.ErrInvalidQuery.HTTPStatus {
+		t.Errorf("response status = %d, expected %d", statusCode, api.ErrInvalidQuery.HTTPStatus)
+	}
+	if respErr.Error == nil {
+		t.Fatal("WriteResult.Error is nil, expected it to be set")
+	}
+	if respErr.Error.Type != api.ErrInvalidQuery.Type {
+		t.Errorf("got error type %s, expected %s", respErr.Error.Type, api.ErrInvalidQuery.Type)
+	}
 
-func TestDeleteEntitiesHandlerEmptyQueryError(t *testing.T) {
-	setup(t)
-	defer teardown(t)
-
-	// Omit query string from URL
-	url := defaultServer.URL + etre.API_ROOT + "/entities/" + entityType
-	expectErr := "query string is empty"
-	testBadRequestError(t, "DELETE", url, expectErr)
+	// Empty query
+	url = defaultServer.URL + etre.API_ROOT + "/entities/" + entityType
+	statusCode, err = test.MakeHTTPRequest("DELETE", url, nil, &respErr)
+	if statusCode != api.ErrInvalidQuery.HTTPStatus {
+		t.Errorf("response status = %d, expected %d", statusCode, api.ErrInvalidQuery.HTTPStatus)
+	}
+	if respErr.Error == nil {
+		t.Fatal("WriteResult.Error is nil, expected it to be set")
+	}
+	if respErr.Error.Type != api.ErrInvalidQuery.Type {
+		t.Errorf("got error type %s, expected %s", respErr.Error.Type, api.ErrInvalidQuery.Type)
+	}
 }
 
 func TestDeleteLabelHandler(t *testing.T) {
@@ -820,27 +903,6 @@ func TestDeleteLabelHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if statusCode != http.StatusForbidden {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusForbidden)
-	}
-}
-
-////////////////////////////////////////////////////////////////////////////
-// Helper Functions
-////////////////////////////////////////////////////////////////////////////
-
-func testBadRequestError(t *testing.T, httpVerb string, url string, expectErr string) {
-	var respErr etre.Error
-
-	statusCode, err := test.MakeHTTPRequest(httpVerb, url, nil, &respErr)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if respErr.Message != expectErr {
-		t.Errorf("response error message = %s, expected %s", respErr.Message, expectErr)
-	}
-
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
 	}

--- a/api/errors.go
+++ b/api/errors.go
@@ -13,9 +13,9 @@ import (
 // uses the fields to create a custom etre.Error and set the HTTP status code.
 
 var ErrDuplicateEntity = etre.Error{
-	Type:       "dupe-entity",
+	Type:       "duplicate-entity",
 	HTTPStatus: http.StatusConflict,
-	Message:    "duplicate entity",
+	Message:    "cannot insert or update entity because identifying labels conflict with another entity",
 }
 
 var ErrNotFound = etre.Error{
@@ -45,19 +45,13 @@ var ErrInvalidQuery = etre.Error{
 var ErrDb = etre.Error{
 	Type:       "db-error",
 	HTTPStatus: http.StatusInternalServerError,
-	Message:    "internal server error",
+	Message:    "unknown database error",
 }
 
 var ErrInternal = etre.Error{
 	Type:       "internal-error",
 	HTTPStatus: http.StatusInternalServerError,
 	Message:    "internal server error",
-}
-
-var ErrBadRequest = etre.Error{
-	Type:       "bad-request",
-	HTTPStatus: http.StatusBadRequest,
-	Message:    "bad request",
 }
 
 var ErrCDCDisabled = etre.Error{

--- a/bin/etre/main.go
+++ b/bin/etre/main.go
@@ -240,7 +240,7 @@ func main() {
 	// //////////////////////////////////////////////////////////////////////
 	// API
 	// //////////////////////////////////////////////////////////////////////
-	api := api.NewAPI(config.Server.Addr, validate, entityStore, feedFactory)
+	api := api.NewAPI(config, validate, entityStore, feedFactory)
 
 	// If you want to add custom middleware for authentication, authorization,
 	// etc., you should do that here. See https://echo.labstack.com/middleware

--- a/bin/etre/main.go
+++ b/bin/etre/main.go
@@ -235,10 +235,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	validate := entity.NewValidator(config.Entity.Types)
+
 	// //////////////////////////////////////////////////////////////////////
 	// API
 	// //////////////////////////////////////////////////////////////////////
-	api := api.NewAPI(config.Server.Addr, entityStore, feedFactory)
+	api := api.NewAPI(config.Server.Addr, validate, entityStore, feedFactory)
 
 	// If you want to add custom middleware for authentication, authorization,
 	// etc., you should do that here. See https://echo.labstack.com/middleware

--- a/cdc/delay_test.go
+++ b/cdc/delay_test.go
@@ -15,7 +15,7 @@ var delayCollection = "cdc"
 
 func delaySetup(t *testing.T) db.Connector {
 	// @todo: make this configurable
-	conn := db.NewConnector("localhost:3000", 1, nil, nil)
+	conn := db.NewConnector("localhost:27017", 1, nil, nil)
 
 	_, err := conn.Connect()
 	if err != nil {

--- a/cdc/store_test.go
+++ b/cdc/store_test.go
@@ -20,7 +20,7 @@ var cdcCollection = "cdc"
 
 func cdcSetup(t *testing.T) db.Connector {
 	// @todo: make this configurable
-	conn := db.NewConnector("localhost:3000", 5, nil, nil)
+	conn := db.NewConnector("localhost:27017", 5, nil, nil)
 	s, err := conn.Connect()
 	if err != nil {
 		t.Errorf("error connecting to mongo: %s", err)

--- a/config/config.go
+++ b/config/config.go
@@ -81,4 +81,7 @@ type ServerConfig struct {
 	// Etre will look at this HTTP header to get the username of the requestor of
 	// all API calls.
 	UsernameHeader string `yaml:"username_header"`
+
+	// If client does not set X-Etre-Version, default to this version.
+	DefaultClientVersion string `yaml:"default_client_version"`
 }

--- a/entity/store.go
+++ b/entity/store.go
@@ -343,7 +343,7 @@ func (s *store) UpdateEntities(wo WriteOp, q query.Query, patch etre.Entity) ([]
 
 	for label := range patch {
 		if etre.IsMetalabel(label) {
-			return nil, fmt.Errorf("updating metalabels is not allowed")
+			return nil, fmt.Errorf("updating metalabel '%s' not allowed", label)
 		}
 	}
 

--- a/entity/validate.go
+++ b/entity/validate.go
@@ -79,7 +79,7 @@ func (v validator) Entities(entities []etre.Entity, op byte) error {
 				// Cannot patch (change) metalabel values
 				if etre.IsMetalabel(label) {
 					return ValidationError{
-						Err:  fmt.Errorf("cannot change metalabel %s value on patch (entity index %d)", label, i),
+						Err:  fmt.Errorf("cannot change metalabel %s on patch (entity index %d)", label, i),
 						Type: "cannot-change-metalabel",
 					}
 				}

--- a/entity/validate.go
+++ b/entity/validate.go
@@ -1,3 +1,4 @@
+// Copyright 2018, Square, Inc.
 package entity
 
 import (
@@ -124,5 +125,6 @@ func (v validator) DeleteLabel(label string) error {
 			Type: "cannot-delete-metalabel",
 		}
 	}
+	// @todo: don't deleting identifying labels
 	return nil
 }

--- a/entity/validate.go
+++ b/entity/validate.go
@@ -1,0 +1,128 @@
+package entity
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/square/etre"
+)
+
+const (
+	VALIDATE_ON_CREATE byte = iota
+	VALIDATE_ON_UPDATE
+	VALIDATE_ON_DELETE
+)
+
+type ValidationError struct {
+	Err  error
+	Type string
+}
+
+func (e ValidationError) Error() string {
+	return e.Err.Error()
+}
+
+type Validator interface {
+	EntityType(string) error
+	Entities([]etre.Entity, byte) error
+	WriteOp(WriteOp) error
+	DeleteLabel(string) error
+}
+
+type validator struct {
+	entityTypes []string
+	validType   map[string]bool
+}
+
+func NewValidator(entityTypes []string) validator {
+	validType := map[string]bool{}
+	for _, t := range entityTypes {
+		validType[t] = true
+	}
+	return validator{
+		entityTypes: entityTypes,
+		validType:   validType,
+	}
+}
+
+func (v validator) EntityType(entityType string) error {
+	if !v.validType[entityType] {
+		return ValidationError{
+			Err:  fmt.Errorf("invalid entity type: %s; valid types (config.entity.types): %s", entityType, strings.Join(v.entityTypes, ", ")),
+			Type: "invalid-entity-type",
+		}
+	}
+	return nil
+}
+
+// Valid returns nils if all the entities are valid.
+func (v validator) Entities(entities []etre.Entity, op byte) error {
+	for i, e := range entities {
+		for label, val := range e {
+			switch op {
+			case VALIDATE_ON_CREATE:
+				// User cannot set these metalabels on create
+				for _, ml := range []string{"_id", "_type", "_rev", "_ts"} {
+					if label != ml {
+						continue
+					}
+					if _, ok := e[ml]; ok {
+						return ValidationError{
+							Err:  fmt.Errorf("cannot set metalabel %s on create (entity index %d)", ml, i),
+							Type: "cannot-set-metalabel",
+						}
+					}
+				}
+			case VALIDATE_ON_UPDATE:
+				// Cannot patch (change) metalabel values
+				if etre.IsMetalabel(label) {
+					return ValidationError{
+						Err:  fmt.Errorf("cannot change metalabel %s value on patch (entity index %d)", label, i),
+						Type: "cannot-change-metalabel",
+					}
+				}
+			}
+
+			// JSON treats all numbers as floats. Given this, when we see a float with
+			// decimal values of all 0, it is unclear if the user passed in 3.0 (type
+			// float) or 3 (type int). So, since we cannot tell the difference between a
+			// some float numbers and integer numbers, we cast all floats to ints. This
+			// means that floats with non-zero decimal values, such as 3.14 (type float),
+			// will get truncated to 3 (type int).
+			if reflect.TypeOf(val).Kind() == reflect.Float64 {
+				entities[i][label] = int(val.(float64))
+			} else {
+				// Values in entity must be of type string or int. This is because the query
+				// language we use only supports querying by string or int. See more at:
+				// github.com/square/etre/query
+				k := reflect.TypeOf(val).Kind()
+				valid := k == reflect.String || k == reflect.Int || k == reflect.Bool
+				if !valid {
+					return ValidationError{
+						Err:  fmt.Errorf("invalid value type %s for key %v (value: %v); valid types: string, int, bool (entity index %d)", reflect.TypeOf(val), label, val, i),
+						Type: "invalid-value-type",
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (v validator) WriteOp(wo WriteOp) error {
+	if err := v.EntityType(wo.EntityType); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v validator) DeleteLabel(label string) error {
+	if etre.IsMetalabel(label) {
+		return ValidationError{
+			Err:  fmt.Errorf("cannot delete metalabel %s", label),
+			Type: "cannot-delete-metalabel",
+		}
+	}
+	return nil
+}

--- a/entity/validate_test.go
+++ b/entity/validate_test.go
@@ -1,0 +1,53 @@
+// Copyright 2017-2018, Square, Inc.
+
+package entity_test
+
+import (
+	"testing"
+
+	"github.com/square/etre"
+	"github.com/square/etre/entity"
+)
+
+var validate = entity.NewValidator(entityTypes)
+
+func TestValidateEntities(t *testing.T) {
+	// All ok
+	entities := []etre.Entity{
+		etre.Entity{"x": 0},
+		etre.Entity{"y": 1},
+	}
+	err := validate.Entities(entities, entity.VALIDATE_ON_CREATE)
+	if err != nil {
+		t.Errorf("got err '%v', expected nil", err)
+	}
+}
+
+func TestValidateWriteOp(t *testing.T) {
+	wo := entity.WriteOp{
+		EntityType: "grue",
+		User:       "dn",
+	}
+	err := validate.WriteOp(wo)
+	if err == nil {
+		t.Fatal("err is nill, expected an enitty.ValidationError")
+	}
+	v, ok := err.(entity.ValidationError)
+	if !ok {
+		t.Fatalf("err is type %#v, expected entity.ValidationError", err)
+	}
+	if v.Type != "invalid-entity-type" {
+		t.Errorf("Type = %s, expected invalid-entity-type", v.Type)
+	}
+}
+
+func TestValidateDeleteLabel(t *testing.T) {
+	err := validate.DeleteLabel("foo")
+	if err != nil {
+		t.Errorf("got err '%v', expected nil", err)
+	}
+	err = validate.DeleteLabel("_id")
+	if err == nil {
+		t.Fatal("err is nill, expected an enitty.ValidationError")
+	}
+}

--- a/entity_client.go
+++ b/entity_client.go
@@ -317,6 +317,7 @@ func (c entityClient) do(method, endpoint string, payload []byte) (*http.Respons
 		return nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Etre-Version", VERSION)
 
 	// Send request
 	resp, err := c.httpClient.Do(req)

--- a/es/es.go
+++ b/es/es.go
@@ -1,4 +1,4 @@
-// Copyright 2017, Square, Inc.
+// Copyright 2017-2018, Square, Inc.
 
 // Package es provides a framework for integration with other programs.
 package es

--- a/es/es.go
+++ b/es/es.go
@@ -131,8 +131,8 @@ func Run(ctx app.Context) {
 	// Finalize options
 	var o config.Options = cmdLine.Options
 	if o.Debug {
-		app.Debug("options: %#v\n", o)
-		app.Debug("set: %#v\n", set)
+		app.Debug("options: %+v\n", o)
+		app.Debug("set: %+v\n", set)
 	}
 
 	if ctx.Hooks.AfterParseOptions != nil {
@@ -143,7 +143,7 @@ func Run(ctx app.Context) {
 
 		// Dump options again to see if hook changed them
 		if o.Debug {
-			app.Debug("options: %#v\n", o)
+			app.Debug("options: %+v\n", o)
 		}
 	}
 	ctx.Options = o
@@ -213,35 +213,20 @@ func Run(ctx app.Context) {
 			patch[p[0]] = p[1]
 		}
 		if o.Debug {
-			app.Debug("patch: %#v", patch)
+			app.Debug("patch: %+v", patch)
 		}
 
 		wr, err := ec.UpdateOne(ctx.EntityId, patch)
+		found, err := writeResult(ctx, set, wr, err, "update")
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "API error: %s\n", err)
+			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}
-		if o.Debug {
-			app.Debug("wr: %#v (%v)", wr, err)
+		if found {
+			fmt.Printf("OK, updated %s %s%s\n", ctx.EntityType, ctx.EntityId, setInfo(set))
+		} else {
+			fmt.Printf("OK, but %s %s did not exist%s\n", ctx.EntityType, ctx.EntityId, setInfo(set))
 		}
-
-		if ctx.Hooks.WriteResult != nil {
-			if o.Debug {
-				app.Debug("calling hook WriteResult")
-			}
-			ctx.Hooks.WriteResult(ctx, wr, err)
-		}
-
-		if wr.Error != "" {
-			fmt.Fprintf(os.Stderr, "API write error: %s\n", wr.Error)
-			os.Exit(1)
-		}
-		if ctx.Options.Old {
-			for _, label := range wr.Diff.Labels() {
-				fmt.Printf("# %s=%v\n", label, wr.Diff[label])
-			}
-		}
-		fmt.Printf("OK, updated %s %s%s\n", ctx.EntityType, ctx.EntityId, setInfo(set))
 		return
 	}
 
@@ -261,7 +246,7 @@ func Run(ctx app.Context) {
 		}
 
 		wr, err := ec.DeleteOne(ctx.EntityId)
-		found, err := writeResult(ctx, set, wr, err)
+		found, err := writeResult(ctx, set, wr, err, "delete")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
@@ -282,7 +267,7 @@ func Run(ctx app.Context) {
 		ctx.EntityId = cmdLine.Args[1]
 		label := cmdLine.Args[2]
 		wr, err := ec.DeleteLabel(ctx.EntityId, label)
-		found, err := writeResult(ctx, set, wr, err)
+		found, err := writeResult(ctx, set, wr, err, "delete label from")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
@@ -404,11 +389,11 @@ func setInfo(set etre.Set) string {
 	return fmt.Sprintf(" (set %s %s)", set.Op, set.Id)
 }
 
-func writeResult(ctx app.Context, set etre.Set, wr etre.WriteResult, err error) (bool, error) {
+func writeResult(ctx app.Context, set etre.Set, wr etre.WriteResult, err error, op string) (bool, error) {
+	// Debug and let hook handle WriteResult
 	if ctx.Options.Debug {
-		app.Debug("wr: %#v (%v)", wr, err)
+		app.Debug("wr: %+v (%v)", wr, err)
 	}
-
 	if ctx.Hooks.WriteResult != nil {
 		if ctx.Options.Debug {
 			app.Debug("calling hook WriteResult")
@@ -416,6 +401,7 @@ func writeResult(ctx app.Context, set etre.Set, wr etre.WriteResult, err error) 
 		ctx.Hooks.WriteResult(ctx, wr, err)
 	}
 
+	// Errors?
 	if err != nil {
 		switch err {
 		case etre.ErrEntityNotFound:
@@ -424,19 +410,25 @@ func writeResult(ctx app.Context, set etre.Set, wr etre.WriteResult, err error) 
 			} else {
 				return false, nil
 			}
+		case etre.ErrNoQuery:
+			return false, fmt.Errorf("No query given")
+		case etre.ErrNoEntity:
+			return false, fmt.Errorf("No entity given")
 		default:
 			return false, err
 		}
 	}
-
-	if wr.Error != "" {
-		return false, fmt.Errorf("API write error: %s\n", wr.Error)
+	if wr.Error != nil {
+		return false, fmt.Errorf("Failed to %s %s %s: %s (%s)", op, ctx.EntityType, ctx.EntityId, wr.Error.Message, wr.Error.Type)
 	}
+
+	// Success
 	if ctx.Options.Old {
-		for _, label := range wr.Diff.Labels() {
-			fmt.Printf("# %s=%v\n", label, wr.Diff[label])
+		for _, wN := range wr.Writes {
+			for _, label := range wN.Diff.Labels() {
+				fmt.Printf("# %s=%v\n", label, wN.Diff[label])
+			}
 		}
 	}
-
 	return true, nil
 }

--- a/etre.go
+++ b/etre.go
@@ -190,7 +190,6 @@ func debug(fmt string, v ...interface{}) {
 type Error struct {
 	Message    string `json:"message"`
 	Type       string `json:"type"`
-	Write      bool   `json:"write"` // write error
 	HTTPStatus int
 }
 

--- a/etre.go
+++ b/etre.go
@@ -142,9 +142,10 @@ type WriteResult struct {
 
 // Write represents the successful write of one entity.
 type Write struct {
-	Id   string `json:"id"`             // internal _id of entity (all write ops)
-	URI  string `json:"uri,omitempty"`  // fully-qualified address of new entity (insert)
-	Diff Entity `json:"diff,omitempty"` // previous entity label values (update)
+	Id    string `json:"id"`              // internal _id of entity (all write ops)
+	URI   string `json:"uri,omitempty"`   // fully-qualified address of new entity (insert)
+	Diff  Entity `json:"diff,omitempty"`  // previous entity label values (update)
+	Error string `json:"error,omitempty"` // v0.8 backward-compatibility
 }
 
 type CDCEvent struct {

--- a/etre.go
+++ b/etre.go
@@ -14,7 +14,7 @@ const (
 	API_ROOT          string = "/api/v1"
 	META_LABEL_ID            = "_id"
 	META_LABEL_TYPE          = "_type"
-	VERSION                  = "0.8.0-alpha"
+	VERSION                  = "0.9.0-alpha"
 	CDC_WRITE_TIMEOUT int    = 5 // seconds
 )
 
@@ -191,6 +191,7 @@ func debug(fmt string, v ...interface{}) {
 type Error struct {
 	Message    string `json:"message"`
 	Type       string `json:"type"`
+	EntityId   string `json:"entityId"`
 	HTTPStatus int
 }
 

--- a/etre.go
+++ b/etre.go
@@ -147,11 +147,15 @@ type Write struct {
 	Error string `json:"error,omitempty"` // v0.8 backward-compatibility
 }
 
+// Error is the standard response for all handled errors. Client errors (HTTP 400
+// codes) and internal errors (HTTP 500 codes) are returned as an Error, if handled.
+// If not handled (API crash, panic, etc.), Etre returns an HTTP 500 code and the
+// response data is undefined; the client should print any response data as a string.
 type Error struct {
-	Message    string `json:"message"`
-	Type       string `json:"type"`
-	EntityId   string `json:"entityId"`
-	HTTPStatus int
+	Message    string `json:"message"`    // human-readable and loggable error message
+	Type       string `json:"type"`       // error slug (e.g. db-error, missing-param, etc.)
+	EntityId   string `json:"entityId"`   // entity ID that caused error, if any
+	HTTPStatus int    `json:"httpStatus"` // HTTP status code
 }
 
 func (e Error) New(msgFmt string, msgArgs ...interface{}) Error {

--- a/query/query.go
+++ b/query/query.go
@@ -11,6 +11,7 @@ package query
 import (
 	"strconv"
 
+	"github.com/globalsign/mgo/bson"
 	"github.com/square/etre/kls"
 )
 
@@ -72,4 +73,18 @@ func translateValues(operator string, values []string) interface{} {
 	}
 
 	return value
+}
+
+// IdEqual returns a Query for "_id=N".
+func IdEqual(id string) Query {
+	// _id is not a valid field name to pass to Translate, so manually create a query object
+	return Query{
+		Predicates: []Predicate{
+			Predicate{
+				Label:    "_id",
+				Operator: "=",
+				Value:    bson.ObjectIdHex(id),
+			},
+		},
+	}
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestTranslateSingle(t *testing.T) {
 	expectedQuery := query.Query{
-		[]query.Predicate{
+		Predicates: []query.Predicate{
 			query.Predicate{
 				Label:    "foo",
 				Operator: "=",
@@ -34,7 +34,7 @@ func TestTranslateSingle(t *testing.T) {
 
 func TestTranslateMultiple(t *testing.T) {
 	expectedQuery := query.Query{
-		[]query.Predicate{
+		Predicates: []query.Predicate{
 			query.Predicate{
 				Label:    "foo",
 				Operator: "=",

--- a/test/util.go
+++ b/test/util.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 )
 
+var Headers = map[string]string{}
+
 // MakeHTTPRequest is a helper function for making an http request. The
 // response body of the http request is unmarshalled into the struct pointed to
 // by the respStruct argument (if it's not nil). The status code of the
@@ -24,6 +26,9 @@ func MakeHTTPRequest(httpVerb, url string, payload []byte, respStruct interface{
 		return statusCode, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	for k, v := range Headers {
+		req.Header.Set(k, v)
+	}
 	res, err := (http.DefaultClient).Do(req)
 	if err != nil {
 		return statusCode, err


### PR DESCRIPTION
#### v0.9
* Add X-Etre-Version  header:
  * es sets = etre.VERSION
  * api uses (in order): header, config.server.default_client_version, etre.VERSION
  * api sends v0.8-compate WriteResult to v0.8 clients
  * Add `config.DefaultClientVersion`
* New `etre.WriteResult` struct (changes `etre.EntityClient` return values)
* Remove  `api.ErrBadRequest` (not used)
* Refactor `entity.Store`:
  * Only one `entity.DbError` (remove other err types)
  * Move validation logic to `entity.Validator`
  * Handle dupe key errors

API v0.9 is backward-compat with client v0.8, but not the reverse. To upgrade:
1. Deploy API v0.9 with `config.server.default_client_version: v0.8`
1. Update clients to v0.9
1. Verify clients
1. Remove `default_client_version` when all clients have been updated