### PR TITLE
Remove db conn mutex and Ping bottleneck

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -89,7 +89,7 @@ func (s *Server) Boot(configFile string) error {
 
 	// Verify we can connect to the db.
 	// @todo: removing this causes mgo panic "Session already closed" after 1st query
-	if _, err = conn.Connect(); err != nil {
+	if err := conn.Init(); err != nil {
 		return fmt.Errorf("cannot connect to %s: %s", cfg.Datasource.URL, err)
 	}
 	log.Printf("Connected to %s", cfg.Datasource.URL)


### PR DESCRIPTION
Th db conn mutex wasn't a perf problem, but the `Ping` on the shared session was. The more clients, the more they bottlenecked on this single connection/session to ping the db. With it, 16 clients would slow to 3 QPS when individually they should do 10 QPS. Without it, all 16 do 10 QPS and query. Another side-effect was query latency: with shared ping it could spike really high (~1s), but without all conn stay consistent around ~200ms.