### PR TITLE
Fix server fatal on db conn error

### DIFF
--- a/cdc/store.go
+++ b/cdc/store.go
@@ -109,7 +109,7 @@ func (s *store) Read(filter Filter) ([]etre.CDCEvent, error) {
 	var events []etre.CDCEvent
 	err = mgoQuery.All(&events)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("database error: %s", err)
 	}
 
 	return events, nil

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ const (
 	DEFAULT_ADDR                  = "127.0.0.1:8050"
 	DEFAULT_DATASOURCE_URL        = "mongodb://localhost:27017"
 	DEFAULT_DB                    = "etre_dev"
-	DEFAULT_DB_TIMEOUT            = 5000
+	DEFAULT_DB_TIMEOUT            = 5
 	DEFAULT_CDC_COLLECTION        = "" // disabled
 	DEFAULT_CDC_DELAY_COLLECTION  = "cdc_delay"
 	DEFAULT_CDC_WRITE_RETRY_COUNT = 3

--- a/config/dev-config.yaml
+++ b/config/dev-config.yaml
@@ -25,13 +25,10 @@ entity:
     - dns
     - grant
 cdc:
-  #collection: cdc
-  fallbackFile:
+  collection: cdc
+  static_delay: -1
   write_retry_count: 2
   write_retry_wait: 300 # milliseconds
-# delay:
-#   collection: delay
-#   static_delay_ms: -1 # milliseconds
-# feed:
-#   streamer_buffer_size: 100
-#   poll_interval: 2000
+feed:
+  streamer_buffer_size: 100
+  poll_interval: 2000


### PR DESCRIPTION
* Restart poller on db error, don't fatal server.
* Start poller in server.Start() not .Boot().
* Fix default db timeout (5s not 5000s).
* Simplify cdc.Poller locking and error return.