### PR TITLE
Better db error handling

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1073,6 +1073,7 @@ func TestMetricsInvalidEntityType(t *testing.T) {
 	// No group/entity metrics because the entity type was invalid
 	expectMetrics := []mock.MetricMethodArgs{
 		{Method: "Inc", Metric: metrics.InvalidEntityType, IntVal: 1},
+		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 	}
 	if diffs := deep.Equal(metricsrec.Called, expectMetrics); diffs != nil {
 		t.Logf("   got (em): %+v", metricsrec.Called)

--- a/api/errors.go
+++ b/api/errors.go
@@ -44,7 +44,7 @@ var ErrInvalidQuery = etre.Error{
 
 var ErrDb = etre.Error{
 	Type:       "db-error",
-	HTTPStatus: http.StatusInternalServerError,
+	HTTPStatus: http.StatusServiceUnavailable,
 	Message:    "unknown database error",
 }
 

--- a/es/config/config.go
+++ b/es/config/config.go
@@ -20,7 +20,7 @@ import (
 const (
 	DEFAULT_CONFIG_FILES = "/etc/etre/es.yaml,~/.es.yaml"
 	DEFAULT_IFS          = ","
-	DEFAULT_TIMEOUT      = 5000 // 5s
+	DEFAULT_TIMEOUT      = 10000 // 10s
 	DEFAULT_RETRY        = 0
 	DEFAULT_RETRY_WAIT   = "1s"
 )


### PR DESCRIPTION
* Increase default es timeout from 5s to 10s (avoid conflict with default 5s db timeout).
* Increment error counts for read queries.
* Return HTTP 503 instead of 500 for db errors.