### PR TITLE
Enable HTTP compression on query responses

### DIFF
--- a/api/api_gomux.go
+++ b/api/api_gomux.go
@@ -137,6 +137,7 @@ func NewAPI(appCtx app.Context) *API {
 	mux.Handle("GET /apidocs/", httpSwagger.Handler())
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		err := ErrEndpointNotFound
 		write := isWriteRequest(r.Method)
@@ -176,6 +177,7 @@ func (api *API) Stop() error {
 
 func (api *API) requestWrapper(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		write := isWriteRequest(r.Method)
 		cdc := strings.HasSuffix(r.URL.String(), "/changes")
 
@@ -981,6 +983,7 @@ func (api *API) metricsHandler(w http.ResponseWriter, r *http.Request) {
 	// plugin can specify zero or more groups.
 	groups := api.metricsStore.Names()
 	if len(groups) == 0 { // no user-defined metric groups
+		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(all)
 		return
 	}
@@ -999,7 +1002,7 @@ func (api *API) metricsHandler(w http.ResponseWriter, r *http.Request) {
 		r.Groups[0].Group = name
 		all.Groups[i] = r.Groups[0]
 	}
-
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(all)
 }
 
@@ -1014,6 +1017,7 @@ func (api *API) statusHandler(w http.ResponseWriter, r *http.Request) {
 		"ok":      "yes",
 		"version": etre.VERSION,
 	}
+	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(status)
 }
 

--- a/test/util.go
+++ b/test/util.go
@@ -42,6 +42,10 @@ func MakeHTTPRequest(httpVerb, url string, payload []byte, respStruct interface{
 		if err := json.Unmarshal(body, &respStruct); err != nil {
 			return statusCode, fmt.Errorf("Can't decode response body: %s: %s", err, string(body))
 		}
+		// Any time we get a JSON response, we should be getting application/json content type
+		if len(res.Header["Content-Type"]) != 1 || res.Header["Content-Type"][0] != "application/json" {
+			return statusCode, fmt.Errorf("server returned incorrect Content-Type: %s", res.Header["Content-Type"])
+		}
 	}
 
 	statusCode = res.StatusCode


### PR DESCRIPTION
Use gzip compression for query responses, if the client allows it. Not added for other response types (single entity requests, update, etc.) since these response payloads are small.

The golang http client supports compression and enables it by default. That means the existing ods-etre-cli client already supports compression and sends the request header `Accept-Encoding: gzip`.  I tested this updated server code with the existing ods-etre-cli build of es and everything works as expected. I also tested with curl both with and without the Accept-Encoding request header and verified that compression is only enabled when the client requests it.