### PR TITLE
Convert tests to use testify assert/require

### DIFF
--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/auth"
@@ -32,10 +33,7 @@ func TestAuthAccessDenied(t *testing.T) {
 	etreurl := server.url + etre.API_ROOT + "/entities/" + entityType + "?query=x"
 	var etreErr etre.Error
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &etreErr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Logf("%+v", etreErr)
+	require.NoError(t, err)
 	if statusCode != http.StatusUnauthorized {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusUnauthorized)
 	}
@@ -45,14 +43,12 @@ func TestAuthAccessDenied(t *testing.T) {
 	etreurl = server.url + etre.API_ROOT + "/entity/" + entityType
 	newEntity := etre.Entity{"host": "local"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	var gotWR etre.WriteResult
 	statusCode, err = test.MakeHTTPRequest("POST", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusUnauthorized {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusUnauthorized)
 	}
@@ -91,9 +87,7 @@ func TestAuthNotAuthorizedWNoACLs(t *testing.T) {
 	etreurl := server.url + etre.API_ROOT + "/entities/" + entityType + "?query=x"
 	var etreErr etre.Error
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &etreErr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Logf("%+v", etreErr)
 	if statusCode != http.StatusForbidden {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusForbidden)
@@ -119,14 +113,10 @@ func TestAuthNotAuthorizedWNoACLs(t *testing.T) {
 	etreurl = server.url + etre.API_ROOT + "/entity/" + entityType
 	newEntity := etre.Entity{"host": "local"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	var gotWR etre.WriteResult
 	statusCode, err = test.MakeHTTPRequest("POST", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if statusCode != http.StatusForbidden {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusForbidden)
 	}

--- a/api/bulk_write_test.go
+++ b/api/bulk_write_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/entity"
@@ -42,17 +43,13 @@ func TestPostEntitiesOK(t *testing.T) {
 	// On create, entities can't have metalabels, so we can't use testEntities
 	entities := []etre.Entity{{"a": "1"}, {"b": "2"}}
 	payload, err := json.Marshal(entities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var gotWR etre.WriteResult
 	url := server.url + etre.API_ROOT + "/entities/" + entityType
 	statusCode, err := test.MakeHTTPRequest("POST", url, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusCreated {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusCreated, gotWR)
@@ -115,16 +112,12 @@ func TestPostEntitiesErrors(t *testing.T) {
 	// On create, entities can't have metalabels, sou use testEntities
 	// which have all the metalabels. This should cause an error.
 	payload, err := json.Marshal(testEntities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("POST", url, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -169,16 +162,13 @@ func TestPostEntitiesErrors(t *testing.T) {
 	entities := []etre.Entity{entity1, entity2}
 
 	payload, err = json.Marshal(entities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("POST", url, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
 	}
@@ -216,15 +206,13 @@ func TestPostEntitiesErrors(t *testing.T) {
 	// Arrays are not supported values types, so this should cause a similar error
 	entities = []etre.Entity{}
 	payload, err = json.Marshal(entities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("POST", url, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
 	}
@@ -264,9 +252,8 @@ func TestPostEntitiesErrors(t *testing.T) {
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("POST", url, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
 	}
@@ -327,9 +314,7 @@ func TestPutEntitiesOK(t *testing.T) {
 	// Set foo=bar on all matching entities (metrics +1 update on "foo")
 	patch := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(patch)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Match entities with a=b (metrics +1 read on "a")
 	etreurl := server.url + etre.API_ROOT + "/entities/" + entityType +
@@ -338,9 +323,7 @@ func TestPutEntitiesOK(t *testing.T) {
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusOK {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusOK, gotWR)
@@ -421,16 +404,12 @@ func TestPutEntitiesErrors(t *testing.T) {
 	etreurl := server.url + etre.API_ROOT + "/entities/" + entityType // missing ?query=...
 	patch := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(patch)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -469,9 +448,7 @@ func TestPutEntitiesErrors(t *testing.T) {
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -512,16 +489,12 @@ func TestPutEntitiesErrors(t *testing.T) {
 
 	patch = etre.Entity{"foo": "bar"}
 	payload, err = json.Marshal(patch)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -559,18 +532,14 @@ func TestPutEntitiesErrors(t *testing.T) {
 
 	patch = etre.Entity{}
 	payload, err = json.Marshal(patch)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	etreurl = server.url + etre.API_ROOT + "/entities/" + entityType +
 		"?query=" + url.QueryEscape("a=b")
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -608,17 +577,13 @@ func TestPutEntitiesErrors(t *testing.T) {
 
 	patch = etre.Entity{"_type": "newType"} // can't change metalabels
 	payload, err = json.Marshal(patch)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	etreurl = server.url + etre.API_ROOT + "/entities/" + entityType +
 		"?query=" + url.QueryEscape("a=b")
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -675,9 +640,7 @@ func TestDeleteEntitiesOK(t *testing.T) {
 	// Set foo=bar on all matching entities (metrics +1 update on "foo")
 	patch := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(patch)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Match entities with a=b (metrics +1 read on "a")
 	etreurl := server.url + etre.API_ROOT + "/entities/" + entityType +
@@ -686,9 +649,7 @@ func TestDeleteEntitiesOK(t *testing.T) {
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("DELETE", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusOK {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusOK, gotWR)
@@ -764,16 +725,12 @@ func TestDeleteEntitiesErrors(t *testing.T) {
 	etreurl := server.url + etre.API_ROOT + "/entities/" + entityType // missing ?query=...
 	patch := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(patch)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("DELETE", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -812,9 +769,7 @@ func TestDeleteEntitiesErrors(t *testing.T) {
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("DELETE", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -855,16 +810,12 @@ func TestDeleteEntitiesErrors(t *testing.T) {
 
 	patch = etre.Entity{"foo": "bar"}
 	payload, err = json.Marshal(patch)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("DELETE", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)

--- a/api/changes_test.go
+++ b/api/changes_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
@@ -39,9 +39,7 @@ func TestChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	latency := client.Ping(time.Duration(300 * time.Millisecond))
-	if latency.Send > 100 || latency.Recv > 100 && latency.RTT > 100 {
-		t.Errorf("Ping latency > 100ms, expected near-zero: %+v", latency)
-	}
+	assert.False(t, latency.Send > 100 || latency.Recv > 100 && latency.RTT > 100, "Ping latency > 100ms, expected near-zero: %+v", latency)
 
 	mux := &sync.Mutex{}
 	events := []etre.CDCEvent{}
@@ -84,13 +82,8 @@ func TestChanges(t *testing.T) {
 		t.Fatal("timeout waiting for recv goroutine to finish")
 	}
 
-	if diff := deep.Equal(events, mock.CDCEvents[0:1]); diff != nil {
-		t.Error(diff)
-	}
-
-	if gotSinceTs != 0 {
-		t.Errorf("got sinceTs = %d, expected 0", gotSinceTs)
-	}
+	assert.Equal(t, mock.CDCEvents[0:1], events)
+	assert.Equal(t, int64(0), gotSinceTs)
 
 	/*
 		@todo Fix data race

--- a/api/changes_test.go
+++ b/api/changes_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/cdc/changestream"
@@ -35,9 +36,7 @@ func TestChanges(t *testing.T) {
 	wsURL := strings.Replace(server.url, "http", "ws", 1)
 	client := etre.NewCDCClient(wsURL, nil, 10, true)
 	eventsChan, err := client.Start(time.Time{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	latency := client.Ping(time.Duration(300 * time.Millisecond))
 	if latency.Send > 100 || latency.Recv > 100 && latency.RTT > 100 {

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
@@ -43,9 +44,8 @@ func setupWithMetrics(t *testing.T, cfg config.Config, store mock.EntityStore) *
 	server.ts = httptest.NewServer(server.api)
 
 	u, err := url.Parse(server.ts.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	server.url = fmt.Sprintf("http://%s", u.Host)
 
 	return server
@@ -64,9 +64,8 @@ func TestMetricsGet(t *testing.T) {
 
 	etreurl := server.url + etre.API_ROOT + "/entities/" + entityType + "?query=x"
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
@@ -75,9 +74,7 @@ func TestMetricsGet(t *testing.T) {
 	etreurl = server.url + etre.API_ROOT + "/metrics"
 	var gotMetrics etre.Metrics
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotMetrics)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusOK {
 		t.Errorf("got HTTP status = %d, expected %d", statusCode, http.StatusOK)
@@ -99,9 +96,8 @@ func TestMetricsInvalidEntityType(t *testing.T) {
 	url := defaultServer.URL + etre.API_ROOT + "/entity/bad-type/" + seedId0
 	var actual etre.Entity
 	statusCode, err := test.MakeHTTPRequest("GET", url, nil, &actual)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
 	}
@@ -140,9 +136,8 @@ func TestMetricsBadRoute(t *testing.T) {
 
 	etreurl := server.url + "/api" // bad route, not under route group
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusNotFound {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
 	}

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -348,7 +348,7 @@ func TestResponseCompression(t *testing.T) {
 
 	// The http client strips the "Content-Encoding" header so we can't check it directly.
 	// Instead, we have to check the "Uncompressed" flag, which will be *true* if the content came back compressed and was decompressed by the http client.
-	assert.True(t, res.Uncompressed, "response was not compressed, expected it to be")
+	assert.True(t, res.Uncompressed, "The server did not send a compressed response. If it had sent a compressed response then the client would have uncompressed it and res.Uncompressed would be true.")
 
 	// Make sure content type is correct
 	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
@@ -41,9 +42,8 @@ func TestQueryBasic(t *testing.T) {
 
 	var gotEntities []etre.Entity
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotEntities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
@@ -90,9 +90,8 @@ func TestQueryBasic(t *testing.T) {
 		"?query=" + url.QueryEscape(q)
 
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotEntities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
@@ -137,9 +136,8 @@ func TestQueryBasic(t *testing.T) {
 		"?query=" + url.QueryEscape(q)
 
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotEntities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
@@ -194,9 +192,7 @@ func TestQueryNoMatches(t *testing.T) {
 
 	var gotEntities []etre.Entity
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotEntities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// HTTP response is still 200 OK because query was ok, there just weren't
 	// any matching queries
@@ -252,9 +248,7 @@ func TestQueryErrorsDatabaseError(t *testing.T) {
 
 	var gotError etre.Error
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusServiceUnavailable { // 503
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusServiceUnavailable)
@@ -309,9 +303,7 @@ func TestQueryErrorsNoEntityType(t *testing.T) {
 
 	var gotError etre.Error
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusNotFound {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
@@ -336,9 +328,8 @@ func TestQueryErrorsNoEntityType(t *testing.T) {
 	etreurl = server.url + etre.API_ROOT + "/entities/?query=" + url.QueryEscape("a=b")
 	gotError = etre.Error{}
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusNotFound {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
 	}
@@ -373,9 +364,7 @@ func TestQueryErrorsTimeout(t *testing.T) {
 
 	var gotError etre.Error
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusServiceUnavailable { // 503
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusServiceUnavailable)
@@ -426,17 +415,13 @@ func TestResponseCompression(t *testing.T) {
 	etreurl := server.url + etre.API_ROOT + "/entities/" + entityType +
 		"?query=" + url.QueryEscape("foo=bar")
 	req, err := http.NewRequest("GET", etreurl, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Make the request
 	// Note that the http client automatically enables gzip, so we don't have to set the "Accept-Encoding" header.
 	res, err := http.DefaultClient.Do(req)
 	defer res.Body.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// The http client strips the "Content-Encoding" header so we can't check it directly.
 	// Instead, we have to check the "Uncompressed" flag, which will be *true* if the content came back compressed and was decompressed by the http client.

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
@@ -44,24 +44,15 @@ func TestQueryBasic(t *testing.T) {
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotEntities)
 	require.NoError(t, err)
 
-	if statusCode != http.StatusOK {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
-	}
-
+	assert.Equal(t, http.StatusOK, statusCode)
 	expectQuery, _ := query.Translate(q)
-	if diff := deep.Equal(gotQuery, expectQuery); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectQuery, gotQuery)
 
 	expectFilter := etre.QueryFilter{}
-	if diff := deep.Equal(gotFilter, expectFilter); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectFilter, gotFilter)
 
 	fixRev(gotEntities) // JSON float64(_rev) ->, int64(_rev)
-	if diffs := deep.Equal(gotEntities, testEntities); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, testEntities, gotEntities)
 
 	// -- Metrics -----------------------------------------------------------
 	expectMetrics := []mock.MetricMethodArgs{
@@ -74,11 +65,7 @@ func TestQueryBasic(t *testing.T) {
 		{Method: "Val", Metric: metrics.ReadMatch, IntVal: 3},              // len(testEntities)
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
-	if diffs := deep.Equal(server.metricsrec.Called, expectMetrics); diffs != nil {
-		t.Logf("   got: %+v", server.metricsrec.Called)
-		t.Logf("expect: %+v", expectMetrics)
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
 	// Multi-label query
@@ -92,19 +79,13 @@ func TestQueryBasic(t *testing.T) {
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotEntities)
 	require.NoError(t, err)
 
-	if statusCode != http.StatusOK {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
-	}
+	assert.Equal(t, http.StatusOK, statusCode)
 
 	expectQuery, _ = query.Translate(q)
-	if diff := deep.Equal(gotQuery, expectQuery); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectQuery, gotQuery)
 
 	expectFilter = etre.QueryFilter{}
-	if diff := deep.Equal(gotFilter, expectFilter); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectFilter, gotFilter)
 
 	// Don't care about the return from the mock store, that was tested above
 
@@ -120,11 +101,7 @@ func TestQueryBasic(t *testing.T) {
 		{Method: "Val", Metric: metrics.ReadMatch, IntVal: 3},              // len(testEntities)
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
-	if diffs := deep.Equal(server.metricsrec.Called, expectMetrics); diffs != nil {
-		t.Logf("   got: %+v", server.metricsrec.Called)
-		t.Logf("expect: %+v", expectMetrics)
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
 	// Single-label exists query
@@ -137,20 +114,13 @@ func TestQueryBasic(t *testing.T) {
 
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotEntities)
 	require.NoError(t, err)
-
-	if statusCode != http.StatusOK {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
-	}
+	assert.Equal(t, http.StatusOK, statusCode)
 
 	expectQuery, _ = query.Translate(q)
-	if diff := deep.Equal(gotQuery, expectQuery); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectQuery, gotQuery)
 
 	expectFilter = etre.QueryFilter{}
-	if diff := deep.Equal(gotFilter, expectFilter); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectFilter, gotFilter)
 
 	// Don't care about the return from the mock store, that was tested above
 
@@ -165,11 +135,7 @@ func TestQueryBasic(t *testing.T) {
 		{Method: "Val", Metric: metrics.ReadMatch, IntVal: 3},                // len(testEntities)
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
-	if diffs := deep.Equal(server.metricsrec.Called, expectMetrics); diffs != nil {
-		t.Logf("   got: %+v", server.metricsrec.Called)
-		t.Logf("expect: %+v", expectMetrics)
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
 func TestQueryNoMatches(t *testing.T) {
@@ -196,19 +162,13 @@ func TestQueryNoMatches(t *testing.T) {
 
 	// HTTP response is still 200 OK because query was ok, there just weren't
 	// any matching queries
-	if statusCode != http.StatusOK {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
-	}
+	assert.Equal(t, http.StatusOK, statusCode)
 
 	expectQuery, _ := query.Translate(q)
-	if diff := deep.Equal(gotQuery, expectQuery); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectQuery, gotQuery)
 
 	// Empty result, no matching queries
-	if diffs := deep.Equal(gotEntities, []etre.Entity{}); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Empty(t, gotEntities)
 
 	// -- Metrics -----------------------------------------------------------
 	expectMetrics := []mock.MetricMethodArgs{
@@ -221,11 +181,7 @@ func TestQueryNoMatches(t *testing.T) {
 		{Method: "Val", Metric: metrics.ReadMatch, IntVal: 0}, // no matching queries
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
-	if diffs := deep.Equal(server.metricsrec.Called, expectMetrics); diffs != nil {
-		t.Logf("   got: %+v", server.metricsrec.Called)
-		t.Logf("expect: %+v", expectMetrics)
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
 // --------------------------------------------------------------------------
@@ -250,18 +206,14 @@ func TestQueryErrorsDatabaseError(t *testing.T) {
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
 	require.NoError(t, err)
 
-	if statusCode != http.StatusServiceUnavailable { // 503
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusServiceUnavailable)
-	}
+	assert.Equal(t, http.StatusServiceUnavailable, statusCode)
 
 	expectError := etre.Error{
 		Message:    "fake error",
 		Type:       "db-read",
 		HTTPStatus: http.StatusServiceUnavailable, // 503
 	}
-	if diffs := deep.Equal(gotError, expectError); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectError, gotError)
 
 	// -- Metrics -----------------------------------------------------------
 	expectMetrics := []mock.MetricMethodArgs{
@@ -274,11 +226,7 @@ func TestQueryErrorsDatabaseError(t *testing.T) {
 		{Method: "Inc", Metric: metrics.DbError, IntVal: 1}, // db error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
-	if diffs := deep.Equal(server.metricsrec.Called, expectMetrics); diffs != nil {
-		t.Logf("   got: %+v", server.metricsrec.Called)
-		t.Logf("expect: %+v", expectMetrics)
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
 func TestQueryErrorsNoEntityType(t *testing.T) {
@@ -305,22 +253,14 @@ func TestQueryErrorsNoEntityType(t *testing.T) {
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
 	require.NoError(t, err)
 
-	if statusCode != http.StatusNotFound {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
-	}
+	assert.Equal(t, http.StatusNotFound, statusCode)
 
 	expectError := api.ErrEndpointNotFound
-	if diffs := deep.Equal(gotError, expectError); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectError, gotError)
 
 	// -- Metrics -----------------------------------------------------------
 	expectMetrics := []mock.MetricMethodArgs{}
-	if diffs := deep.Equal(server.metricsrec.Called, expectMetrics); diffs != nil {
-		t.Logf("   got: %+v", server.metricsrec.Called)
-		t.Logf("expect: %+v", expectMetrics)
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
 	// With trailing slash to ensure API doesn't pass "" for :type
@@ -330,19 +270,11 @@ func TestQueryErrorsNoEntityType(t *testing.T) {
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
 	require.NoError(t, err)
 
-	if statusCode != http.StatusNotFound {
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
-	}
-	if diffs := deep.Equal(gotError, expectError); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, http.StatusNotFound, statusCode)
+	assert.Equal(t, expectError, gotError)
 
 	// -- Metrics -----------------------------------------------------------
-	if diffs := deep.Equal(server.metricsrec.Called, expectMetrics); diffs != nil {
-		t.Logf("   got: %+v", server.metricsrec.Called)
-		t.Logf("expect: %+v", expectMetrics)
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
 func TestQueryErrorsTimeout(t *testing.T) {
@@ -366,13 +298,8 @@ func TestQueryErrorsTimeout(t *testing.T) {
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
 	require.NoError(t, err)
 
-	if statusCode != http.StatusServiceUnavailable { // 503
-		t.Errorf("response status = %d, expected %d", statusCode, http.StatusServiceUnavailable)
-	}
-
-	if gotError.Type != "db-read" {
-		t.Errorf("got etre.Error.Type = %s, expected \"db-read\": %+v", gotError.Type, gotError)
-	}
+	assert.Equal(t, http.StatusServiceUnavailable, statusCode)
+	assert.Equal(t, "db-read", gotError.Type)
 
 	if len(server.metricsrec.Called) == 8 {
 		if server.metricsrec.Called[7].Metric != metrics.LatencyMs || server.metricsrec.Called[7].IntVal < 90 || server.metricsrec.Called[7].IntVal > 150 {
@@ -394,11 +321,7 @@ func TestQueryErrorsTimeout(t *testing.T) {
 		{Method: "Inc", Metric: metrics.QueryTimeout, IntVal: 1}, // query timeout
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
-	if diffs := deep.Equal(server.metricsrec.Called, expectMetrics); diffs != nil {
-		t.Logf("   got: %+v", server.metricsrec.Called)
-		t.Logf("expect: %+v", expectMetrics)
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
 func TestResponseCompression(t *testing.T) {
@@ -425,12 +348,8 @@ func TestResponseCompression(t *testing.T) {
 
 	// The http client strips the "Content-Encoding" header so we can't check it directly.
 	// Instead, we have to check the "Uncompressed" flag, which will be *true* if the content came back compressed and was decompressed by the http client.
-	if !res.Uncompressed {
-		t.Errorf("response was not compressed, expected it to be")
-	}
+	assert.True(t, res.Uncompressed, "response was not compressed, expected it to be")
 
 	// Make sure content type is correct
-	if res.Header.Get("Content-Type") != "application/json" {
-		t.Errorf("response Content-Type = %s, expected application/json", res.Header.Get("Content-Type"))
-	}
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
 }

--- a/api/single_entity_read_test.go
+++ b/api/single_entity_read_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
@@ -42,9 +43,8 @@ func TestGetEntityBasic(t *testing.T) {
 
 	var gotEntity etre.Entity
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
@@ -100,9 +100,8 @@ func TestGetEntityReturnLabels(t *testing.T) {
 
 	var gotEntity etre.Entity
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}
@@ -147,9 +146,8 @@ func TestGetEntityNotFound(t *testing.T) {
 
 	var gotEntity etre.Entity
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusNotFound {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
 	}
@@ -198,9 +196,8 @@ func TestGetEntityErrors(t *testing.T) {
 
 	gotError = etre.Error{}
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
 	}
@@ -234,9 +231,8 @@ func TestGetEntityErrors(t *testing.T) {
 
 	gotError = etre.Error{}
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	// This is 404 not 400 (bad request) because there's no endpoint for /entity/:type
 	if statusCode != http.StatusNotFound {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
@@ -267,9 +263,8 @@ func TestGetEntityErrors(t *testing.T) {
 	etreurl = server.url + etre.API_ROOT + "/entity/" + entityType + "/" + testEntityIds[0]
 	gotError = etre.Error{}
 	statusCode, err = test.MakeHTTPRequest("GET", etreurl, nil, &gotError)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusServiceUnavailable {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusServiceUnavailable)
 	}
@@ -318,9 +313,8 @@ func TestGetEntityLabels(t *testing.T) {
 
 	var gotLabels []string
 	statusCode, err := test.MakeHTTPRequest("GET", etreurl, nil, &gotLabels)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
 	}

--- a/api/single_entity_write_test.go
+++ b/api/single_entity_write_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
@@ -42,17 +43,13 @@ func TestPostEntityOK(t *testing.T) {
 
 	newEntity := etre.Entity{"host": "local"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl := server.url + etre.API_ROOT + "/entity/" + entityType
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("POST", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusCreated {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusCreated)
@@ -114,17 +111,13 @@ func TestPostEntityDuplicate(t *testing.T) {
 
 	newEntity := etre.Entity{"host": "local"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl := server.url + etre.API_ROOT + "/entity/" + entityType
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("POST", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusConflict {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusConflict)
@@ -171,17 +164,13 @@ func TestPostEntityErrors(t *testing.T) {
 	// ----------------------------------------------------------------------
 	newEntity := etre.Entity{"host": "local", "_id": testEntityIds[0]}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl := server.url + etre.API_ROOT + "/entity/" + entityType
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("POST", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
@@ -220,16 +209,13 @@ func TestPostEntityErrors(t *testing.T) {
 
 	newEntity = etre.Entity{}
 	payload, err = json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("POST", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
 	}
@@ -268,9 +254,8 @@ func TestPostEntityErrors(t *testing.T) {
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("POST", etreurl, payload, &gotWR)
 	t.Logf("got WriteResult: %+v", gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("got HTTP status = %d, expected %d: %+v", statusCode, http.StatusBadRequest, gotWR)
 	}
@@ -326,17 +311,13 @@ func TestPutEntityOK(t *testing.T) {
 
 	newEntity := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl := server.url + etre.API_ROOT + "/entity/" + entityType + "/" + testEntityIds[0]
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
@@ -408,17 +389,13 @@ func TestPutEntityDuplicate(t *testing.T) {
 
 	newEntity := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl := server.url + etre.API_ROOT + "/entity/" + entityType + "/" + testEntityIds[0]
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusConflict {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusConflict)
@@ -462,17 +439,13 @@ func TestPutEntityNotFound(t *testing.T) {
 
 	newEntity := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl := server.url + etre.API_ROOT + "/entity/" + entityType + "/" + testEntityIds[0]
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusNotFound {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
@@ -516,9 +489,7 @@ func TestPutEntityErrors(t *testing.T) {
 
 	newEntity := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// ----------------------------------------------------------------------
 	// Missing entity id (:id)
@@ -530,9 +501,7 @@ func TestPutEntityErrors(t *testing.T) {
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusNotFound {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusNotFound)
@@ -566,9 +535,7 @@ func TestPutEntityErrors(t *testing.T) {
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
@@ -611,17 +578,13 @@ func TestPutEntityErrors(t *testing.T) {
 	// Patch can't have _id
 	newEntity = etre.Entity{"_id": testEntityIds[0], "foo": "bar"}
 	payload, err = json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl = server.url + etre.API_ROOT + "/entity/" + entityType + "/" + testEntityIds[0]
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
@@ -663,17 +626,13 @@ func TestPutEntityErrors(t *testing.T) {
 
 	newEntity = etre.Entity{}
 	payload, err = json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl = server.url + etre.API_ROOT + "/entity/" + entityType + "/" + testEntityIds[0]
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
@@ -718,9 +677,7 @@ func TestPutEntityErrors(t *testing.T) {
 
 	gotWR = etre.WriteResult{}
 	statusCode, err = test.MakeHTTPRequest("PUT", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusBadRequest {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusBadRequest)
@@ -782,17 +739,13 @@ func TestDeleteEntityOK(t *testing.T) {
 
 	newEntity := etre.Entity{"foo": "bar"}
 	payload, err := json.Marshal(newEntity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	etreurl := server.url + etre.API_ROOT + "/entity/" + entityType + "/" + testEntityIds[0]
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("DELETE", etreurl, payload, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)
@@ -869,9 +822,7 @@ func TestDeleteLabel(t *testing.T) {
 
 	var gotWR etre.WriteResult
 	statusCode, err := test.MakeHTTPRequest("DELETE", etreurl, nil, &gotWR)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if statusCode != http.StatusOK {
 		t.Errorf("response status = %d, expected %d", statusCode, http.StatusOK)

--- a/app/instrument_test.go
+++ b/app/instrument_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/square/etre/app"
 )
 
@@ -36,9 +37,7 @@ func TestInstrumentOneBlockOneCall(t *testing.T) {
 			Time:  time.Duration(2 * time.Second),
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expect, got)
 }
 
 func TestInstrumentManyBlocksOneCall(t *testing.T) {
@@ -68,10 +67,7 @@ func TestInstrumentManyBlocksOneCall(t *testing.T) {
 		{Block: "c", Level: 1, Calls: 1, Time: time.Duration(3 * time.Second)},
 		{Block: "?", Level: 1, Calls: 0, Time: time.Duration(1 * time.Second)},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Logf("%+v", got)
-		t.Error(diff)
-	}
+	assert.Equal(t, expect, got)
 }
 
 func TestInstrumentNestedBlockCall(t *testing.T) {
@@ -98,7 +94,5 @@ func TestInstrumentNestedBlockCall(t *testing.T) {
 		{Block: "b", Level: 2, Calls: 1, Time: time.Duration(2 * time.Second)},
 		{Block: "?", Level: 1, Calls: 0, Time: time.Duration(1 * time.Second)},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expect, got)
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -25,9 +25,7 @@ func TestAllowAll(t *testing.T) {
 		Name:         "",
 		MetricGroups: []string{"etre"},
 	}
-	if diffs := deep.Equal(caller, expectCaller); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectCaller, caller)
 	action := auth.Action{
 		EntityType: "foo",
 		Op:         auth.OP_READ,
@@ -72,12 +70,8 @@ func TestManager(t *testing.T) {
 	// If plugin.Authenticate returns nil error, and caller has no required trace keys,
 	// then manager just returns caller from plugin.
 	gotCaller, err := man.Authenticate(&http.Request{})
-	if err != authErr {
-		t.Errorf("got Authenticate error '%v', expected '%v'", err, authErr)
-	}
-	if diffs := deep.Equal(gotCaller, caller); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, authErr, err)
+	assert.Equal(t, caller, gotCaller)
 
 	// Trace key requirements
 	// ---------------------------------------------------------------------------
@@ -168,16 +162,11 @@ func TestManagerNoACLs(t *testing.T) {
 
 	gotCaller, err := man.Authenticate(&http.Request{})
 	require.NoError(t, err)
-
-	if diffs := deep.Equal(gotCaller, caller); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, caller, gotCaller)
 
 	err = man.Authorize(caller, auth.Action{EntityType: "foo", Op: auth.OP_WRITE})
 	require.NoError(t, err)
-	if !authorizeCalled {
-		t.Errorf("auth plugin Authorize called, expected it to be called without ACLs")
-	}
+	assert.True(t, authorizeCalled, "auth plugin Authorize called, expected it to be called without ACLs")
 }
 
 func TestManagerAuthenticateError(t *testing.T) {
@@ -203,12 +192,8 @@ func TestManagerAuthenticateError(t *testing.T) {
 	authErr = fmt.Errorf("forced test error")
 
 	gotCaller, err := man.Authenticate(&http.Request{})
-	if err != authErr {
-		t.Errorf("got Authenticate error '%v', expected '%v'", err, authErr)
-	}
-	if diffs := deep.Equal(gotCaller, caller); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, authErr, err)
+	assert.Equal(t, caller, gotCaller)
 }
 
 func TestTraceHeader(t *testing.T) {
@@ -228,10 +213,7 @@ func TestTraceHeader(t *testing.T) {
 	}
 	gotCaller, err := man.Authenticate(req)
 	require.NoError(t, err)
-
-	if diffs := deep.Equal(gotCaller, expectCaller); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectCaller, gotCaller)
 
 	// Bad values are silently ignored
 	req, _ = http.NewRequest("GET", "http://example.com", nil)
@@ -241,20 +223,14 @@ func TestTraceHeader(t *testing.T) {
 	}
 	gotCaller, err = man.Authenticate(req)
 	require.NoError(t, err)
-
-	if diffs := deep.Equal(gotCaller, expectCaller); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectCaller, gotCaller)
 
 	req, _ = http.NewRequest("GET", "http://example.com", nil)
 	req.Header.Set(etre.TRACE_HEADER, "") // empty value
 	expectCaller.Trace = nil
 	gotCaller, err = man.Authenticate(req)
 	require.NoError(t, err)
-
-	if diffs := deep.Equal(gotCaller, expectCaller); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectCaller, gotCaller)
 
 	// Values set by plugin are not changed
 	caller := auth.Caller{
@@ -278,8 +254,5 @@ func TestTraceHeader(t *testing.T) {
 	}
 	gotCaller, err = man.Authenticate(req)
 	require.NoError(t, err)
-
-	if diffs := deep.Equal(gotCaller, expectCaller); diffs != nil {
-		t.Error(diffs)
-	}
+	assert.Equal(t, expectCaller, gotCaller)
 }

--- a/cdc/changestream/client_test.go
+++ b/cdc/changestream/client_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/cdc/changestream"
@@ -55,9 +56,8 @@ func setupClient(t *testing.T, streamer changestream.Streamer) *server {
 		defer close(server.doneChan)
 		var upgrader = websocket.Upgrader{}
 		wsConn, err := upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		clientNo++
 		clientId := fmt.Sprintf("client%d", clientNo)
 		server.Lock()
@@ -77,9 +77,8 @@ func setupClient(t *testing.T, streamer changestream.Streamer) *server {
 	}
 	server.ts = httptest.NewServer(http.HandlerFunc(wsHandler))
 	u, err := url.Parse(server.ts.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	server.url = fmt.Sprintf("ws://%s", u.Host)
 	return server
 }
@@ -94,9 +93,7 @@ func TestClientWebsocketPingFromClient(t *testing.T) {
 
 	// Connect to server.ts/wsHandler
 	clientConn, _, err := websocket.DefaultDialer.Dial(server.url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer clientConn.Close()
 
 	srcTs := time.Now()
@@ -135,9 +132,7 @@ func TestClientWebsocketPingToClient(t *testing.T) {
 
 	// Connect to server.ts/wsHandler
 	clientConn, _, err := websocket.DefaultDialer.Dial(server.url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer clientConn.Close()
 
 	<-server.clientRunning
@@ -204,9 +199,7 @@ func TestClientStreamer(t *testing.T) {
 
 	// Connect to server.ts/wsHandler
 	clientConn, _, err := websocket.DefaultDialer.Dial(server.url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer clientConn.Close()
 
 	startTs := 1
@@ -293,9 +286,7 @@ func TestClientInvalidMessageType(t *testing.T) {
 
 	// Connect to server.ts/wsHandler
 	clientConn, _, err := websocket.DefaultDialer.Dial(server.url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer clientConn.Close()
 
 	// Messages are supposed to be map[string]interface{}, so []int is invalid
@@ -328,9 +319,7 @@ func TestClientInvalidMessageContent(t *testing.T) {
 
 	// Connect to server.ts/wsHandler
 	clientConn, _, err := websocket.DefaultDialer.Dial(server.url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer clientConn.Close()
 
 	// This would be valid except "control": "ping" is missing
@@ -364,9 +353,7 @@ func TestClientClose(t *testing.T) {
 
 	// Connect to server.ts/wsHandler
 	clientConn, _, err := websocket.DefaultDialer.Dial(server.url, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Start streamer so that goroutine is running
 	startTs := 1

--- a/cdc/changestream/server_test.go
+++ b/cdc/changestream/server_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 
@@ -31,9 +32,7 @@ func setup(t *testing.T) {
 	if coll == nil {
 		var err error
 		client, coll, err = test.DbCollections(entityTypes)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		store = cdc.NewStore(coll["cdc"], "", cdc.NoRetryPolicy)
 	}
@@ -41,9 +40,7 @@ func setup(t *testing.T) {
 	// Reset the collection: delete all cdc events and insert the standard cdc events
 	cdcColl := coll[entityType]
 	_, err := cdcColl.DeleteMany(context.TODO(), bson.D{{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 // --------------------------------------------------------------------------
@@ -62,9 +59,7 @@ func TestServer(t *testing.T) {
 	time.Sleep(200 * time.Millisecond) // given server.Run() a moment to start
 
 	stream, err := server.Watch("c1")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if err := store.Write(context.TODO(), events1[0]); err != nil {
 		t.Fatal(err)
@@ -103,9 +98,7 @@ func TestServerClientBlock(t *testing.T) {
 	time.Sleep(200 * time.Millisecond) // given server.Run() a moment to start
 
 	stream, err := server.Watch("c1")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if err := store.Write(context.TODO(), events1[0]); err != nil {
 		t.Fatal(err)
@@ -133,9 +126,7 @@ func TestServerStop(t *testing.T) {
 	time.Sleep(200 * time.Millisecond) // given server.Run() a moment to start
 
 	stream, err := server.Watch("c1")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	time.Sleep(200 * time.Millisecond)
 

--- a/cdc/changestream/server_test.go
+++ b/cdc/changestream/server_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -33,7 +33,6 @@ func setup(t *testing.T) {
 		var err error
 		client, coll, err = test.DbCollections(entityTypes)
 		require.NoError(t, err)
-
 		store = cdc.NewStore(coll["cdc"], "", cdc.NoRetryPolicy)
 	}
 
@@ -72,10 +71,7 @@ func TestServer(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout waiting for change stream channel")
 	}
-
-	if diff := deep.Equal(gotEvent, events1[0]); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, events1[0], gotEvent)
 
 	server.Close("c1")
 	select {

--- a/cdc/changestream/stream_test.go
+++ b/cdc/changestream/stream_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/square/etre"
 	"github.com/square/etre/cdc"
@@ -72,9 +72,7 @@ func TestStreamNow(t *testing.T) {
 		Running:  true,
 		InSync:   true,
 	}
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 
 	// Server sends 1 event (real MongoDBServer would do this when MongoDB change stream
 	// pushes a raw event). It should be sent immediately to client on streamChan.
@@ -84,16 +82,11 @@ func TestStreamNow(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timeout waiting for event on streamChan")
 	}
-
-	if diff := deep.Equal(gotEvent, events1[0]); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, events1[0], gotEvent)
 
 	// Status should be unchanged
 	gotStatus = stream.Status()
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 
 	// Stop the streamer and check the status
 	stream.Stop()
@@ -103,9 +96,7 @@ func TestStreamNow(t *testing.T) {
 		Running:  false, // this changes to false after calling Stop
 		InSync:   true,
 	}
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 
 	// Stop is idempotent
 	stream.Stop()
@@ -115,9 +106,7 @@ func TestStreamNow(t *testing.T) {
 		Running:  false, // this changes to false after calling Stop
 		InSync:   true,
 	}
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 }
 
 func TestStreamBacklogNoNewEvents(t *testing.T) {
@@ -161,17 +150,13 @@ func TestStreamBacklogNoNewEvents(t *testing.T) {
 	// That value is nondeterministic, but it must be < when the test start (nowTs).
 	// Also, for the baclog we order by Ts ascending because, internally, the steamer
 	// uses an etre.RevOrder to handle out of order events.
-	if gotFilter.UntilTs < nowTs {
-		t.Errorf("got cdc.Filter.UntilTs = %d, expected >= %d", gotFilter.UntilTs, nowTs)
-	}
+	assert.Greater(t, gotFilter.UntilTs, nowTs)
 	gotFilter.UntilTs = 0
 	expectFilter := cdc.Filter{
 		SinceTs: 100,
 		Order:   cdc.ByTsAsc{},
 	}
-	if diff := deep.Equal(gotFilter, expectFilter); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectFilter, gotFilter)
 
 	// Since we didn't send any current events on serverChan, the internal buff
 	// is zero-length which makes shiftToCurrent() return immediately and backlog()
@@ -190,9 +175,7 @@ func TestStreamBacklogNoNewEvents(t *testing.T) {
 		InSync:      true,
 		BufferUsage: []int{changestream.ServerBufferSize, 0, 0},
 	}
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 }
 
 func TestStreamBacklogNewEvents(t *testing.T) {
@@ -282,10 +265,7 @@ func TestStreamBacklogNewEvents(t *testing.T) {
 		InSync:      true,
 		BufferUsage: []int{changestream.ServerBufferSize, 1, 1},
 	}
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Logf("%+v", gotStatus)
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 
 	// Get all events sent to client which should be backlog + newEvent
 	gotEvents := []etre.CDCEvent{}
@@ -296,9 +276,7 @@ func TestStreamBacklogNewEvents(t *testing.T) {
 	expectEvents := make([]etre.CDCEvent, len(events1)+1)
 	copy(expectEvents, events1)
 	expectEvents[len(expectEvents)-1] = newEvent
-	if diff := deep.Equal(gotEvents, expectEvents); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectEvents, gotEvents)
 
 	// Stop the streamer and check the status. This is important becuase the backlog
 	// starts and coordinates several goroutines, so Stop() shouldn't hang waiting for
@@ -311,9 +289,7 @@ func TestStreamBacklogNewEvents(t *testing.T) {
 		InSync:      true,
 		BufferUsage: []int{changestream.ServerBufferSize, 1, 1},
 	}
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 }
 
 func TestStreamBacklogNewOverlappingEvents(t *testing.T) {
@@ -381,9 +357,7 @@ func TestStreamBacklogNewOverlappingEvents(t *testing.T) {
 		e := <-streamChan
 		gotEvents = append(gotEvents, e)
 	}
-	if diff := deep.Equal(gotEvents, events1); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, events1, gotEvents)
 }
 
 func TestStreamNewEventsOutOfOrder(t *testing.T) {
@@ -429,9 +403,7 @@ func TestStreamNewEventsOutOfOrder(t *testing.T) {
 			break
 		}
 	}
-	if diff := deep.Equal(gotEvents, events1); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, events1, gotEvents)
 }
 
 func TestStreamServerClosedStreamDuringBacklog(t *testing.T) {
@@ -492,16 +464,11 @@ func TestStreamServerClosedStreamDuringBacklog(t *testing.T) {
 		BufferUsage:        []int{changestream.ServerBufferSize, 0, 0},
 		ServerClosedStream: true,
 	}
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 
 	// Error() should return changestream.ErrServerClosedStream
 	err := stream.Error()
-	if err != changestream.ErrServerClosedStream {
-		t.Errorf("got error '%s', expected '%s' (changestream.ErrServerClosedStream)",
-			err, changestream.ErrServerClosedStream)
-	}
+	assert.Equal(t, changestream.ErrServerClosedStream, err)
 }
 
 func TestStreamServerClosedStreamDuringSync(t *testing.T) {
@@ -539,14 +506,9 @@ func TestStreamServerClosedStreamDuringSync(t *testing.T) {
 		InSync:             true,
 		ServerClosedStream: true,
 	}
-	if diff := deep.Equal(gotStatus, expectStatus); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStatus, gotStatus)
 
 	// changestream.ErrServerClosedStream should be reported
 	err := stream.Error()
-	if err != changestream.ErrServerClosedStream {
-		t.Errorf("got error '%s', expected '%s' (changestream.ErrServerClosedStream)",
-			err, changestream.ErrServerClosedStream)
-	}
+	assert.Equal(t, changestream.ErrServerClosedStream, err)
 }

--- a/cdc/changestream/stream_test.go
+++ b/cdc/changestream/stream_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
 	"github.com/square/etre/cdc"
@@ -450,9 +451,8 @@ func TestStreamServerClosedStreamDuringBacklog(t *testing.T) {
 
 	// Get that 1 backlog event, then wait for ServerStreamer to close client chan
 	// (last thing it does on shutdown)
-	if err := waitUntilClosed(streamChan); err != nil {
-		t.Fatal(err)
-	}
+	err := waitUntilClosed(streamChan)
+	require.NoError(t, err)
 
 	// Status should reflect that we're not running, were not in sync, did have the
 	// backlog buffer, and the server closed the stream
@@ -467,7 +467,7 @@ func TestStreamServerClosedStreamDuringBacklog(t *testing.T) {
 	assert.Equal(t, expectStatus, gotStatus)
 
 	// Error() should return changestream.ErrServerClosedStream
-	err := stream.Error()
+	err = stream.Error()
 	assert.Equal(t, changestream.ErrServerClosedStream, err)
 }
 
@@ -493,9 +493,8 @@ func TestStreamServerClosedStreamDuringSync(t *testing.T) {
 	close(serverChan)
 
 	// Wait for ServerStreamer to close client chan (last thing it does on shutdown)
-	if err := waitUntilClosed(streamChan); err != nil {
-		t.Fatal(err)
-	}
+	err := waitUntilClosed(streamChan)
+	require.NoError(t, err)
 
 	// Status should reflect that we were in sync and the server closed the stream.
 	// No BufferUsage becuse we didn't have a backlog.
@@ -509,6 +508,6 @@ func TestStreamServerClosedStreamDuringSync(t *testing.T) {
 	assert.Equal(t, expectStatus, gotStatus)
 
 	// changestream.ErrServerClosedStream should be reported
-	err := stream.Error()
+	err = stream.Error()
 	assert.Equal(t, changestream.ErrServerClosedStream, err)
 }

--- a/cdc/store_test.go
+++ b/cdc/store_test.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -90,9 +90,7 @@ func TestRead(t *testing.T) {
 	}
 
 	expectedIds := []string{"p34", "vno", "4pi"} // order matters
-	if diff := deep.Equal(actualIds, expectedIds); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectedIds, actualIds)
 
 	// Filter #2.
 	filter = cdc.Filter{
@@ -109,11 +107,7 @@ func TestRead(t *testing.T) {
 	}
 
 	expectedIds = []string{"nru", "p34", "61p", "qwp", "vno", "4pi", "vb0", "bnu"} // order matters
-	if diff := deep.Equal(actualIds, expectedIds); diff != nil {
-		t.Logf("expected: %v", expectedIds)
-		t.Logf("     got: %v", actualIds)
-		t.Error(diff)
-	}
+	assert.Equal(t, expectedIds, actualIds)
 }
 
 func TestWriteSuccess(t *testing.T) {
@@ -145,14 +139,8 @@ func TestWriteSuccess(t *testing.T) {
 	}
 	actualEvents, err := cdcs.Read(filter)
 	require.NoError(t, err)
-
-	if len(actualEvents) != 1 {
-		t.Errorf("got back %d events, expected 1", len(actualEvents))
-	}
-
-	if diff := deep.Equal(event, actualEvents[0]); diff != nil {
-		t.Error(diff)
-	}
+	assert.Len(t, actualEvents, 1)
+	assert.Equal(t, event, actualEvents[0])
 }
 
 func TestWriteFallbackFile(t *testing.T) {
@@ -179,9 +167,7 @@ func TestWriteFallbackFile(t *testing.T) {
 	if err := json.Unmarshal(bytes, &gotEvent); err != nil {
 		t.Fatal(err)
 	}
-	if diff := deep.Equal(gotEvent, event); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, event, gotEvent)
 }
 
 type sortTest struct {
@@ -193,66 +179,62 @@ func TestSortByEntityIdRev(t *testing.T) {
 	sortTests := []sortTest{
 		{
 			rand: []etre.CDCEvent{
-				etre.CDCEvent{Id: "a", EntityId: "e1", EntityRev: 1, Ts: 1}, // written second (rev=1) but logged first at ts=1
-				etre.CDCEvent{Id: "b", EntityId: "e1", EntityRev: 0, Ts: 2}, // written first (rev=0) but logged second at ts=2
+				{Id: "a", EntityId: "e1", EntityRev: 1, Ts: 1}, // written second (rev=1) but logged first at ts=1
+				{Id: "b", EntityId: "e1", EntityRev: 0, Ts: 2}, // written first (rev=0) but logged second at ts=2
 			},
 			wro: []etre.CDCEvent{
-				etre.CDCEvent{Id: "b", EntityId: "e1", EntityRev: 0, Ts: 2}, // rev 0 must be before
-				etre.CDCEvent{Id: "a", EntityId: "e1", EntityRev: 1, Ts: 1}, // rev 1 regardless of ts
+				{Id: "b", EntityId: "e1", EntityRev: 0, Ts: 2}, // rev 0 must be before
+				{Id: "a", EntityId: "e1", EntityRev: 1, Ts: 1}, // rev 1 regardless of ts
 			},
 		},
 		{
 			rand: []etre.CDCEvent{
-				etre.CDCEvent{Id: "a", EntityId: "e1", EntityRev: 1, Ts: 1}, // written second, logged at same time
-				etre.CDCEvent{Id: "b", EntityId: "e1", EntityRev: 0, Ts: 1}, // written first, logged at same time
+				{Id: "a", EntityId: "e1", EntityRev: 1, Ts: 1}, // written second, logged at same time
+				{Id: "b", EntityId: "e1", EntityRev: 0, Ts: 1}, // written first, logged at same time
 			},
 			wro: []etre.CDCEvent{
-				etre.CDCEvent{Id: "b", EntityId: "e1", EntityRev: 0, Ts: 1}, // rev 0 must be before
-				etre.CDCEvent{Id: "a", EntityId: "e1", EntityRev: 1, Ts: 1}, // rev 1 regardless of ts
+				{Id: "b", EntityId: "e1", EntityRev: 0, Ts: 1}, // rev 0 must be before
+				{Id: "a", EntityId: "e1", EntityRev: 1, Ts: 1}, // rev 1 regardless of ts
 			},
 		},
 		{
 			rand: []etre.CDCEvent{
-				etre.CDCEvent{Id: "a", EntityId: "e1", EntityRev: 3, Ts: 1}, // same entity badly out of order
-				etre.CDCEvent{Id: "b", EntityId: "e1", EntityRev: 2, Ts: 1},
-				etre.CDCEvent{Id: "c", EntityId: "e1", EntityRev: 0, Ts: 2},
-				etre.CDCEvent{Id: "d", EntityId: "e1", EntityRev: 1, Ts: 3},
+				{Id: "a", EntityId: "e1", EntityRev: 3, Ts: 1}, // same entity badly out of order
+				{Id: "b", EntityId: "e1", EntityRev: 2, Ts: 1},
+				{Id: "c", EntityId: "e1", EntityRev: 0, Ts: 2},
+				{Id: "d", EntityId: "e1", EntityRev: 1, Ts: 3},
 			},
 			wro: []etre.CDCEvent{
-				etre.CDCEvent{Id: "c", EntityId: "e1", EntityRev: 0, Ts: 2}, // rev order matters for same entity
-				etre.CDCEvent{Id: "d", EntityId: "e1", EntityRev: 1, Ts: 3},
-				etre.CDCEvent{Id: "b", EntityId: "e1", EntityRev: 2, Ts: 1},
-				etre.CDCEvent{Id: "a", EntityId: "e1", EntityRev: 3, Ts: 1},
+				{Id: "c", EntityId: "e1", EntityRev: 0, Ts: 2}, // rev order matters for same entity
+				{Id: "d", EntityId: "e1", EntityRev: 1, Ts: 3},
+				{Id: "b", EntityId: "e1", EntityRev: 2, Ts: 1},
+				{Id: "a", EntityId: "e1", EntityRev: 3, Ts: 1},
 			},
 		},
 		{
 			rand: []etre.CDCEvent{
-				etre.CDCEvent{Id: "a", EntityId: "e1", EntityRev: 3, Ts: 1}, // two different entities badly out of order
-				etre.CDCEvent{Id: "b", EntityId: "e1", EntityRev: 1, Ts: 3}, // ts also out of order, which could happen
-				etre.CDCEvent{Id: "c", EntityId: "e9", EntityRev: 0, Ts: 2}, // because we don't ask db to sort by anything
-				etre.CDCEvent{Id: "d", EntityId: "e1", EntityRev: 0, Ts: 2},
-				etre.CDCEvent{Id: "e", EntityId: "e9", EntityRev: 1, Ts: 1},
-				etre.CDCEvent{Id: "f", EntityId: "e1", EntityRev: 2, Ts: 1},
-				etre.CDCEvent{Id: "g", EntityId: "e9", EntityRev: 2, Ts: 3},
+				{Id: "a", EntityId: "e1", EntityRev: 3, Ts: 1}, // two different entities badly out of order
+				{Id: "b", EntityId: "e1", EntityRev: 1, Ts: 3}, // ts also out of order, which could happen
+				{Id: "c", EntityId: "e9", EntityRev: 0, Ts: 2}, // because we don't ask db to sort by anything
+				{Id: "d", EntityId: "e1", EntityRev: 0, Ts: 2},
+				{Id: "e", EntityId: "e9", EntityRev: 1, Ts: 1},
+				{Id: "f", EntityId: "e1", EntityRev: 2, Ts: 1},
+				{Id: "g", EntityId: "e9", EntityRev: 2, Ts: 3},
 			},
 			wro: []etre.CDCEvent{
-				etre.CDCEvent{Id: "d", EntityId: "e1", EntityRev: 0, Ts: 2},
-				etre.CDCEvent{Id: "b", EntityId: "e1", EntityRev: 1, Ts: 3},
-				etre.CDCEvent{Id: "f", EntityId: "e1", EntityRev: 2, Ts: 1},
-				etre.CDCEvent{Id: "a", EntityId: "e1", EntityRev: 3, Ts: 1},
-				etre.CDCEvent{Id: "c", EntityId: "e9", EntityRev: 0, Ts: 2},
-				etre.CDCEvent{Id: "e", EntityId: "e9", EntityRev: 1, Ts: 1},
-				etre.CDCEvent{Id: "g", EntityId: "e9", EntityRev: 2, Ts: 3},
+				{Id: "d", EntityId: "e1", EntityRev: 0, Ts: 2},
+				{Id: "b", EntityId: "e1", EntityRev: 1, Ts: 3},
+				{Id: "f", EntityId: "e1", EntityRev: 2, Ts: 1},
+				{Id: "a", EntityId: "e1", EntityRev: 3, Ts: 1},
+				{Id: "c", EntityId: "e9", EntityRev: 0, Ts: 2},
+				{Id: "e", EntityId: "e9", EntityRev: 1, Ts: 1},
+				{Id: "g", EntityId: "e9", EntityRev: 2, Ts: 3},
 			},
 		},
 	}
 
 	for i, s := range sortTests {
 		sort.Sort(cdc.ByEntityIdRevAsc(s.rand)) // sorts s.rand in place
-		if diff := deep.Equal(s.rand, s.wro); diff != nil {
-			t.Logf("expected: %v", s.wro)
-			t.Logf("     got: %v", s.rand)
-			t.Errorf("sort test %d failed, see output above: %v", i, diff)
-		}
+		assert.Equal(t, s.wro, s.rand, "sort test %d failed", i)
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -14,6 +14,9 @@ import (
 
 	"github.com/go-test/deep"
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/square/etre"
 )
 
@@ -152,9 +155,7 @@ func TestQueryOK(t *testing.T) {
 	query := "x=y"
 	expectQuery := "query=" + query
 	got, err := ec.Query(query, etre.QueryFilter{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Verify call and response
 	expectPath := etre.API_ROOT + "/entities/node"
@@ -180,9 +181,8 @@ func TestQueryNoResults(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 
 	got, err := ec.Query("any=thing", etre.QueryFilter{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if diff := deep.Equal(got, respData); diff != nil {
 		t.Error(diff)
 	}
@@ -201,15 +201,12 @@ func TestQueryHandledError(t *testing.T) {
 
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 	got, err := ec.Query("any=thing", etre.QueryFilter{})
-	if err == nil {
-		t.Error("err is nil, expected an error")
-	}
+	require.Error(t, err)
+
 	if !strings.Contains(err.Error(), respError.Message) {
 		t.Errorf("error message does not contain '%s': '%s'", respError.Message, err)
 	}
-	if got != nil {
-		t.Errorf("got entities, expected nil: %v", got)
-	}
+	assert.Nil(t, got)
 }
 
 func TestQueryUnhandledError(t *testing.T) {
@@ -223,9 +220,7 @@ func TestQueryUnhandledError(t *testing.T) {
 
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 	got, err := ec.Query("any=thing", etre.QueryFilter{})
-	if err == nil {
-		t.Fatal("err is nil, expected an error")
-	}
+	require.Error(t, err)
 	if !strings.Contains(err.Error(), "no response") {
 		t.Errorf("error does not contain 'no response': '%s'", err)
 	}
@@ -262,9 +257,7 @@ func TestInsertOK(t *testing.T) {
 		},
 	}
 	got, err := ec.Insert(entities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Verify call and response
 	if gotMethod != "POST" {
@@ -300,9 +293,8 @@ func TestInsertAPIError(t *testing.T) {
 		},
 	}
 	got, err := ec.Insert(entities)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if diff := deep.Equal(got, respData.(etre.WriteResult)); diff != nil {
 		t.Error(diff)
 	}
@@ -320,9 +312,8 @@ func TestInsertUnhandledError(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 	entities := []etre.Entity{{"foo": "bar"}}
 	wr, err := ec.Insert(entities)
-	if err == nil {
-		t.Fatal(err)
-	}
+	require.Error(t, err)
+
 	if !strings.Contains(err.Error(), "no response") {
 		t.Errorf("error does not contain 'no response': '%s'", err)
 	}
@@ -374,9 +365,7 @@ func TestUpdateOK(t *testing.T) {
 		"foo": "bar", // patch foo:foo -> for:bar
 	}
 	got, err := ec.Update("foo=bar", entity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Verify call and response
 	if gotMethod != "PUT" {
@@ -407,9 +396,7 @@ func TestUpdateAPIError(t *testing.T) {
 		"foo": "bar",
 	}
 	got, err := ec.Update("foo=bar", entity)
-	if err == nil {
-		t.Fatal("err is nil, expected an error")
-	}
+	require.Error(t, err)
 
 	// The etre.Error.Message should bubble up
 	if !strings.Contains(err.Error(), respError.Message) {
@@ -465,9 +452,7 @@ func TestUpdateOneOK(t *testing.T) {
 		"foo": "bar", // patch foo:foo -> for:bar
 	}
 	got, err := ec.UpdateOne("abc", entity)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if gotMethod != "PUT" {
 		t.Errorf("got method %s, expected PUT", gotMethod)
@@ -507,9 +492,7 @@ func TestDeleteOK(t *testing.T) {
 	// Normal delete that returns status code 200 and a write result
 	query := "foo=bar"
 	got, err := ec.Delete(query)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Verify call and response
 	if gotMethod != "DELETE" {
@@ -557,9 +540,7 @@ func TestDeleteWithSet(t *testing.T) {
 	// Normal delete that returns status code 200 and a write result
 	query := "foo=bar"
 	got, err := ec.Delete(query)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Verify call and response
 	if gotMethod != "DELETE" {
@@ -601,9 +582,8 @@ func TestDeleteOneOK(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 
 	got, err := ec.DeleteOne("abc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if gotMethod != "DELETE" {
 		t.Errorf("got method %s, expected DELETE", gotMethod)
 	}
@@ -642,9 +622,7 @@ func TestDeleteOneWithSet(t *testing.T) {
 	ec = ec.WithSet(set)
 
 	got, err := ec.DeleteOne("abc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if gotMethod != "DELETE" {
 		t.Errorf("got method %s, expected DELETE", gotMethod)
 	}
@@ -674,9 +652,7 @@ func TestLabelsOK(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 
 	got, err := ec.Labels("abc")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if gotMethod != "GET" {
 		t.Errorf("got method %s, expected GET", gotMethod)
 	}
@@ -707,9 +683,7 @@ func TestDeleteLabelOK(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 
 	got, err := ec.DeleteLabel("abc", "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if gotMethod != "DELETE" {
 		t.Errorf("got method %s, expected DELETE", gotMethod)
@@ -745,19 +719,12 @@ func TestCDCClient(t *testing.T) {
 		var upgrader = websocket.Upgrader{}
 		var err error
 		wsConn, err = upgrader.Upgrade(w, r, nil)
-		if err != nil {
-			t.Fatal(err)
-			return
-		}
+		require.NoError(t, err)
 		defer wsConn.Close()
-		if err := wsConn.ReadJSON(&gotStart); err != nil {
-			t.Fatal(err)
-			return
-		}
-		if err := wsConn.WriteJSON(startAck); err != nil {
-			t.Fatal(err)
-			return
-		}
+		err = wsConn.ReadJSON(&gotStart)
+		require.NoError(t, err)
+		err = wsConn.WriteJSON(startAck)
+		require.NoError(t, err)
 		connChan <- true
 		<-connChan
 	}
@@ -772,9 +739,7 @@ func TestCDCClient(t *testing.T) {
 
 	startTs := time.Now()
 	events, err := ec.Start(startTs)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Wait for wsHandler ^ to do start sequence
 	select {
@@ -892,19 +857,13 @@ func TestCDCClient(t *testing.T) {
 		var err error
 
 		err = wsConn.ReadJSON(&ping)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+		require.NoError(t, err)
+
 		time.Sleep(101 * time.Millisecond)
 		ping["control"] = "pong"
 		ping["dstTs"] = time.Now().UnixNano()
-		t.Logf("%#v", ping)
 		err = wsConn.WriteJSON(ping)
-		if err != nil {
-			t.Error(err)
-			return
-		}
+		require.NoError(t, err)
 
 		close(waitForPing)
 	}()
@@ -932,18 +891,13 @@ func TestCDCClient(t *testing.T) {
 		"error":   "fake error",
 	}
 	err = wsConn.WriteJSON(errorMsg)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	require.NoError(t, err)
 
 	// Give client a few milliseconds to shutdown
 	time.Sleep(500 * time.Millisecond)
 	var rand map[string]interface{} // shouldn't read random data
 	err = wsConn.ReadJSON(&rand)
-	if err == nil {
-		t.Errorf("no error read, expected an error; read %#v", rand)
-	}
+	require.Error(t, err)
 
 	// The client should save the error ^ and return it
 	gotError := ec.Error().Error()

--- a/client_test.go
+++ b/client_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -647,12 +646,8 @@ func TestCDCClient(t *testing.T) {
 
 	// Start should be idempotent
 	events2, err2 := ec.Start(startTs)
-	if err2 != nil {
-		t.Errorf("got error %s, expected none", err2)
-	}
-	if events2 != events {
-		t.Errorf("Start did not return same events chan, expected same one")
-	}
+	assert.NoError(t, err2)
+	assert.Equal(t, events, events2, "Start did not return same events chan, expected same one")
 
 	// Verify client sent correct start control message
 
@@ -667,11 +662,7 @@ func TestCDCClient(t *testing.T) {
 	bytes, _ := json.Marshal(v)
 	var expectStart map[string]interface{}
 	json.Unmarshal(bytes, &expectStart)
-	if diff := deep.Equal(gotStart, expectStart); diff != nil {
-		t.Logf("gotStart: %#v", gotStart)
-		t.Logf("expectStart: %s", string(bytes))
-		t.Error(diff)
-	}
+	assert.Equal(t, expectStart, gotStart)
 
 	// First, let's send the client a CDC event and make sure it sends via the
 	// events chan it returned from Start()
@@ -700,10 +691,7 @@ func TestCDCClient(t *testing.T) {
 	}
 
 	// The event we got should be the event we sent--that's the whole point!
-	if diff := deep.Equal(gotEvent, sentEvent); diff != nil {
-		t.Logf("%#v", gotStart)
-		t.Error(diff)
-	}
+	assert.Equal(t, sentEvent, gotEvent)
 
 	//
 	// Send client a ping control message (server -> client ping)

--- a/client_test.go
+++ b/client_test.go
@@ -92,9 +92,7 @@ func setup(t *testing.T) {
 func TestEntityType(t *testing.T) {
 	setup(t)
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
-	if ec.EntityType() != "node" {
-		t.Errorf("got entity type %s, expected node", ec.EntityType())
-	}
+	assert.Equal(t, "node", ec.EntityType())
 }
 
 func TestQueryAndIdRequired(t *testing.T) {
@@ -109,29 +107,27 @@ func TestQueryAndIdRequired(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 
 	// All methods that take query string should return ErrNoQuery if not given one
-	if _, err := ec.Query("", etre.QueryFilter{}); err != etre.ErrNoQuery {
-		t.Errorf("got error %v, expected etre.ErrNoQuery", err)
-	}
-	if _, err := ec.Update("", entities[0]); err != etre.ErrNoQuery {
-		t.Errorf("got error %v, expected etre.ErrNoQuery", err)
-	}
-	if _, err := ec.Delete(""); err != etre.ErrNoQuery {
-		t.Errorf("got error %v, expected etre.ErrNoQuery", err)
-	}
+	_, err := ec.Query("", etre.QueryFilter{})
+	assert.ErrorIs(t, err, etre.ErrNoQuery)
+
+	_, err = ec.Update("", entities[0])
+	assert.ErrorIs(t, err, etre.ErrNoQuery)
+
+	_, err = ec.Delete("")
+	assert.ErrorIs(t, err, etre.ErrNoQuery)
 
 	// All methods that take id string should return ErrIdNotSet if not given one
-	if _, err := ec.UpdateOne("", entities[0]); err != etre.ErrIdNotSet {
-		t.Errorf("got error %v, expected etre.ErrIdNotSet", err)
-	}
-	if _, err := ec.DeleteOne(""); err != etre.ErrIdNotSet {
-		t.Errorf("got error %v, expected etre.ErrIdNotSet", err)
-	}
-	if _, err := ec.Labels(""); err != etre.ErrIdNotSet {
-		t.Errorf("got error %v, expected etre.ErrIdNotSet", err)
-	}
-	if _, err := ec.DeleteLabel("", "foo"); err != etre.ErrIdNotSet {
-		t.Errorf("got error %v, expected etre.ErrIdNotSet", err)
-	}
+	_, err = ec.UpdateOne("", entities[0])
+	assert.ErrorIs(t, err, etre.ErrIdNotSet)
+
+	_, err = ec.DeleteOne("")
+	assert.ErrorIs(t, err, etre.ErrIdNotSet)
+
+	_, err = ec.Labels("")
+	assert.ErrorIs(t, err, etre.ErrIdNotSet)
+
+	_, err = ec.DeleteLabel("", "foo")
+	assert.ErrorIs(t, err, etre.ErrIdNotSet)
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -153,21 +149,14 @@ func TestQueryOK(t *testing.T) {
 
 	// Normal query that returns status code 200 and respData
 	query := "x=y"
-	expectQuery := "query=" + query
 	got, err := ec.Query(query, etre.QueryFilter{})
 	require.NoError(t, err)
 
 	// Verify call and response
-	expectPath := etre.API_ROOT + "/entities/node"
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if gotQuery != expectQuery {
-		t.Errorf("got query %s, expected %s", gotQuery, expectQuery)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "GET", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entities/node", gotPath)
+	assert.Equal(t, "query="+query, gotQuery)
+	assert.Equal(t, got, respData)
 }
 
 func TestQueryNoResults(t *testing.T) {
@@ -182,10 +171,7 @@ func TestQueryNoResults(t *testing.T) {
 
 	got, err := ec.Query("any=thing", etre.QueryFilter{})
 	require.NoError(t, err)
-
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, respData, got)
 }
 
 func TestQueryHandledError(t *testing.T) {
@@ -202,10 +188,7 @@ func TestQueryHandledError(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 	got, err := ec.Query("any=thing", etre.QueryFilter{})
 	require.Error(t, err)
-
-	if !strings.Contains(err.Error(), respError.Message) {
-		t.Errorf("error message does not contain '%s': '%s'", respError.Message, err)
-	}
+	assert.True(t, strings.Contains(err.Error(), respError.Type), "error message does not contain '%s': '%s'", respError.Message, err)
 	assert.Nil(t, got)
 }
 
@@ -221,12 +204,8 @@ func TestQueryUnhandledError(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 	got, err := ec.Query("any=thing", etre.QueryFilter{})
 	require.Error(t, err)
-	if !strings.Contains(err.Error(), "no response") {
-		t.Errorf("error does not contain 'no response': '%s'", err)
-	}
-	if got != nil {
-		t.Errorf("got entities, expected nil: %v", got)
-	}
+	assert.True(t, strings.Contains(err.Error(), "no response"), "error message does not contain 'no response': '%s'", err)
+	assert.Nil(t, got)
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -260,16 +239,10 @@ func TestInsertOK(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify call and response
-	if gotMethod != "POST" {
-		t.Errorf("got method %s, expected POST", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entities/node"
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "POST", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entities/node", gotPath)
+	assert.Empty(t, gotQuery)
+	assert.Equal(t, respData, got)
 }
 
 func TestInsertAPIError(t *testing.T) {
@@ -294,10 +267,7 @@ func TestInsertAPIError(t *testing.T) {
 	}
 	got, err := ec.Insert(entities)
 	require.NoError(t, err)
-
-	if diff := deep.Equal(got, respData.(etre.WriteResult)); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, respData, got)
 }
 
 func TestInsertUnhandledError(t *testing.T) {
@@ -313,13 +283,8 @@ func TestInsertUnhandledError(t *testing.T) {
 	entities := []etre.Entity{{"foo": "bar"}}
 	wr, err := ec.Insert(entities)
 	require.Error(t, err)
-
-	if !strings.Contains(err.Error(), "no response") {
-		t.Errorf("error does not contain 'no response': '%s'", err)
-	}
-	if !wr.IsZero() {
-		t.Errorf("non-zero WriteResult, expected no WriteResult: %+v", wr)
-	}
+	assert.True(t, strings.Contains(err.Error(), "no response"), "error message does not contain 'no response': '%s'", err)
+	assert.Zero(t, wr)
 }
 
 func TestInsertNoEntityError(t *testing.T) {
@@ -330,12 +295,8 @@ func TestInsertNoEntityError(t *testing.T) {
 	// A zero length slice of entities should return ErrNoEntity
 	entities := []etre.Entity{}
 	got, err := ec.Insert(entities)
-	if err != etre.ErrNoEntity {
-		t.Fatalf("err is '%s', expected ErrNoEtity", err)
-	}
-	if got.Writes != nil {
-		t.Errorf("got []etre.WriteResult, expected nil: %#v", got)
-	}
+	assert.ErrorIs(t, err, etre.ErrNoEntity)
+	assert.Nil(t, got.Writes)
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -368,16 +329,10 @@ func TestUpdateOK(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify call and response
-	if gotMethod != "PUT" {
-		t.Errorf("got method %s, expected PUT", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entities/node"
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "PUT", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entities/node", gotPath)
+	assert.Equal(t, "query=foo=bar", gotQuery)
+	assert.Equal(t, respData, got)
 }
 
 func TestUpdateAPIError(t *testing.T) {
@@ -399,14 +354,10 @@ func TestUpdateAPIError(t *testing.T) {
 	require.Error(t, err)
 
 	// The etre.Error.Message should bubble up
-	if !strings.Contains(err.Error(), respError.Message) {
-		t.Errorf("error does not contain '%s': %s", respError.Message, err)
-	}
+	assert.True(t, strings.Contains(err.Error(), respError.Message), "error does not contain '%s': %s", respError.Message, err)
 
 	// There should not be any entities returned
-	if got.Writes != nil {
-		t.Errorf("got []etre.WriteResult, expected nil: %#v", got)
-	}
+	assert.Nil(t, got.Writes)
 }
 
 func TestUpdateNoEntityError(t *testing.T) {
@@ -417,12 +368,8 @@ func TestUpdateNoEntityError(t *testing.T) {
 	// A zero length slice of entities should return ErrNoEntity
 	entity := etre.Entity{}
 	got, err := ec.Update("foo=bar", entity)
-	if err != etre.ErrNoEntity {
-		t.Fatalf("err is '%s', expected ErrNoEtity", err)
-	}
-	if got.Writes != nil {
-		t.Errorf("got []etre.WriteResult, expected nil: %#v", got)
-	}
+	assert.ErrorIs(t, err, etre.ErrNoEntity)
+	assert.Nil(t, got.Writes)
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -453,17 +400,10 @@ func TestUpdateOneOK(t *testing.T) {
 	}
 	got, err := ec.UpdateOne("abc", entity)
 	require.NoError(t, err)
-
-	if gotMethod != "PUT" {
-		t.Errorf("got method %s, expected PUT", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entity/node/abc"
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "PUT", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entity/node/abc", gotPath)
+	assert.Empty(t, gotQuery)
+	assert.Equal(t, respData, got)
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -495,20 +435,10 @@ func TestDeleteOK(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify call and response
-	if gotMethod != "DELETE" {
-		t.Errorf("got method %s, expected DELETE", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entities/node"
-	expectQuery := "query=" + query
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if gotQuery != expectQuery {
-		t.Errorf("got query %s, expected %s", gotQuery, expectQuery)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "DELETE", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entities/node", gotPath)
+	assert.Equal(t, "query="+query, gotQuery)
+	assert.Equal(t, respData, got)
 }
 
 func TestDeleteWithSet(t *testing.T) {
@@ -543,20 +473,11 @@ func TestDeleteWithSet(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify call and response
-	if gotMethod != "DELETE" {
-		t.Errorf("got method %s, expected DELETE", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entities/node"
-	expectQuery := "query=" + query + "&setId=setid&setOp=setop&setSize=3"
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if gotQuery != expectQuery {
-		t.Errorf("got query %s, expected %s", gotQuery, expectQuery)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "DELETE", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entities/node", gotPath)
+	assert.Equal(t, "query="+query+"&setId=setid&setOp=setop&setSize=3", gotQuery)
+	assert.Equal(t, respData, got)
+
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -584,16 +505,10 @@ func TestDeleteOneOK(t *testing.T) {
 	got, err := ec.DeleteOne("abc")
 	require.NoError(t, err)
 
-	if gotMethod != "DELETE" {
-		t.Errorf("got method %s, expected DELETE", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entity/node/abc"
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "DELETE", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entity/node/abc", gotPath)
+	assert.Empty(t, gotQuery)
+	assert.Equal(t, respData, got)
 }
 
 func TestDeleteOneWithSet(t *testing.T) {
@@ -623,20 +538,10 @@ func TestDeleteOneWithSet(t *testing.T) {
 
 	got, err := ec.DeleteOne("abc")
 	require.NoError(t, err)
-	if gotMethod != "DELETE" {
-		t.Errorf("got method %s, expected DELETE", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entity/node/abc"
-	expectQuery := "setId=setid&setOp=setop&setSize=2" // testing this
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if gotQuery != expectQuery {
-		t.Errorf("got query %s, expected %s", gotQuery, expectQuery)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "DELETE", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entity/node/abc", gotPath)
+	assert.Equal(t, "setId=setid&setOp=setop&setSize=2", gotQuery)
+	assert.Equal(t, respData, got)
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -653,16 +558,10 @@ func TestLabelsOK(t *testing.T) {
 
 	got, err := ec.Labels("abc")
 	require.NoError(t, err)
-	if gotMethod != "GET" {
-		t.Errorf("got method %s, expected GET", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entity/node/abc/labels"
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "GET", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entity/node/abc/labels", gotPath)
+	assert.Empty(t, gotQuery)
+	assert.Equal(t, respData, got)
 }
 
 func TestDeleteLabelOK(t *testing.T) {
@@ -684,17 +583,10 @@ func TestDeleteLabelOK(t *testing.T) {
 
 	got, err := ec.DeleteLabel("abc", "foo")
 	require.NoError(t, err)
-
-	if gotMethod != "DELETE" {
-		t.Errorf("got method %s, expected DELETE", gotMethod)
-	}
-	expectPath := etre.API_ROOT + "/entity/node/abc/labels/foo"
-	if gotPath != expectPath {
-		t.Errorf("got path %s, expected %s", gotPath, expectPath)
-	}
-	if diff := deep.Equal(got, respData); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, "DELETE", gotMethod)
+	assert.Equal(t, etre.API_ROOT+"/entity/node/abc/labels/foo", gotPath)
+	assert.Empty(t, gotQuery)
+	assert.Equal(t, respData, got)
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -831,20 +723,11 @@ func TestCDCClient(t *testing.T) {
 		t.Fatal(err)
 		return
 	}
-	if pong["control"] != "pong" {
-		t.Errorf("wrong control reply '%s', expected 'ping'", pong["control"])
-	}
+	assert.Equal(t, "pong", pong["control"])
+
 	ts, ok := pong["dstTs"]
-	if !ok {
-		t.Errorf("dstTs not set in ping reply, expected a UnixNano value")
-	} else {
-		// Go JSON makes all numbers float64, so convert to that first,
-		// then int64 for UnixNano.
-		n := int64(ts.(float64))
-		if n <= startTs.UnixNano() {
-			t.Errorf("got ts %d <= sent ts %d, expected it to be greater", n, startTs.UnixNano())
-		}
-	}
+	require.True(t, ok, "dstTs not set in ping reply, expected a UnixNano value")
+	assert.True(t, int64(ts.(float64)) > startTs.UnixNano(), "got ts %v <= sent ts %d, expected it to be greater", ts, startTs.UnixNano())
 
 	//
 	// Ping server (client -> server ping)
@@ -874,9 +757,7 @@ func TestCDCClient(t *testing.T) {
 	// Ping to wsConn.ReadJSON in the gorountine above. Since that's local
 	// it's microseconds. But the time.Sleep in the goroutine creates an
 	// artificial Send and RTT lag.
-	if lag.Send < 101 || lag.RTT < 101 {
-		t.Errorf("got zero lag, exected > 100ms values: %#v", lag)
-	}
+	assert.False(t, lag.Send < 101 || lag.RTT < 101, "got zero lag, exected > 100ms values: %#v", lag)
 
 	<-waitForPing
 
@@ -901,7 +782,5 @@ func TestCDCClient(t *testing.T) {
 
 	// The client should save the error ^ and return it
 	gotError := ec.Error().Error()
-	if !strings.Contains(gotError, "fake error") {
-		t.Errorf("got error '%s', expected 'fake error'", gotError)
-	}
+	assert.Contains(t, gotError, "fake error")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -188,7 +187,7 @@ func TestQueryHandledError(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 	got, err := ec.Query("any=thing", etre.QueryFilter{})
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), respError.Type), "error message does not contain '%s': '%s'", respError.Message, err)
+	assert.Contains(t, err.Error(), respError.Type)
 	assert.Nil(t, got)
 }
 
@@ -204,7 +203,7 @@ func TestQueryUnhandledError(t *testing.T) {
 	ec := etre.NewEntityClient("node", ts.URL, httpClient)
 	got, err := ec.Query("any=thing", etre.QueryFilter{})
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no response"), "error message does not contain 'no response': '%s'", err)
+	assert.Contains(t, err.Error(), "no response")
 	assert.Nil(t, got)
 }
 
@@ -283,7 +282,7 @@ func TestInsertUnhandledError(t *testing.T) {
 	entities := []etre.Entity{{"foo": "bar"}}
 	wr, err := ec.Insert(entities)
 	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no response"), "error message does not contain 'no response': '%s'", err)
+	assert.Contains(t, err.Error(), "no response")
 	assert.Zero(t, wr)
 }
 
@@ -354,7 +353,7 @@ func TestUpdateAPIError(t *testing.T) {
 	require.Error(t, err)
 
 	// The etre.Error.Message should bubble up
-	assert.True(t, strings.Contains(err.Error(), respError.Message), "error does not contain '%s': %s", respError.Message, err)
+	assert.Contains(t, err.Error(), respError.Message)
 
 	// There should not be any entities returned
 	assert.Nil(t, got.Writes)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre/config"
 )
@@ -58,9 +59,7 @@ func TestDatasourceConfigDefaults(t *testing.T) {
 func TestLoadEmpty(t *testing.T) {
 	cfg := config.Default()
 	got, err := config.Load("../test/config/empty.yaml", cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if diff := deep.Equal(got, config.Default()); diff != nil {
 		t.Error(diff)
 	}
@@ -68,9 +67,7 @@ func TestLoadEmpty(t *testing.T) {
 
 func TestLoadTest001(t *testing.T) {
 	got, err := config.Load("../test/config/test001.yaml", config.Default())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	expect := config.Default()
 	expect.Server.Addr = "10.0.0.1:1234"
@@ -86,9 +83,7 @@ func TestLoadTest001(t *testing.T) {
 
 func TestLoadTest002(t *testing.T) {
 	got, err := config.Load("../test/config/test002.yaml", config.Default())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	expect := config.Default()
 	expect.CDC.Disabled = true // testing this

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,7 +5,6 @@ package config_test
 import (
 	"testing"
 
-	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -29,9 +28,7 @@ func TestDatasourceConfigDefaults(t *testing.T) {
 	}
 	c := config.DatasourceConfig{}
 	c = c.WithDefaults(d)
-	if diff := deep.Equal(c, d); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, d, c)
 
 	c = config.DatasourceConfig{
 		URL:            "c1",
@@ -52,9 +49,7 @@ func TestDatasourceConfigDefaults(t *testing.T) {
 		Mechanism:      "k",
 	}
 	c = c.WithDefaults(d)
-	if diff := deep.Equal(c, m); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, m, c)
 }
 
 func TestLoadEmpty(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre/config"
@@ -60,9 +61,7 @@ func TestLoadEmpty(t *testing.T) {
 	cfg := config.Default()
 	got, err := config.Load("../test/config/empty.yaml", cfg)
 	require.NoError(t, err)
-	if diff := deep.Equal(got, config.Default()); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, cfg, got)
 }
 
 func TestLoadTest001(t *testing.T) {
@@ -75,10 +74,7 @@ func TestLoadTest001(t *testing.T) {
 	expect.Datasource.Database = "test_db"
 	expect.Entity.Types = []string{"test"}
 	expect.Metrics.QueryLatencySLA = "10ms"
-
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expect, got)
 }
 
 func TestLoadTest002(t *testing.T) {
@@ -87,8 +83,5 @@ func TestLoadTest002(t *testing.T) {
 
 	expect := config.Default()
 	expect.CDC.Disabled = true // testing this
-
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expect, got)
 }

--- a/entity/validate_test.go
+++ b/entity/validate_test.go
@@ -17,8 +17,8 @@ var validate = entity.NewValidator(entityTypes)
 func TestValidateCreateEntitiesOK(t *testing.T) {
 	// All ok
 	entities := []etre.Entity{
-		etre.Entity{"x": 0},
-		etre.Entity{"y": 1},
+		{"x": 0},
+		{"y": 1},
 	}
 	err := validate.Entities(entities, entity.VALIDATE_ON_CREATE)
 	require.NoError(t, err)
@@ -26,94 +26,58 @@ func TestValidateCreateEntitiesOK(t *testing.T) {
 
 func TestValidateCreateEntitiesErrorsMetalabels(t *testing.T) {
 	invalid := []etre.Entity{
-		etre.Entity{"a": "b", "_id": "59f10d2a5669fc79103a1111"}, // _id not allowed
-		etre.Entity{"a": "b", "_type": "node"},                   // _type not allowed
-		etre.Entity{"a": "b", "_rev": int64(0)},                  // _rev not allowed
+		{"a": "b", "_id": "59f10d2a5669fc79103a1111"}, // _id not allowed
+		{"a": "b", "_type": "node"},                   // _type not allowed
+		{"a": "b", "_rev": int64(0)},                  // _rev not allowed
 	}
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_CREATE)
 		assert.Errorf(t, err, "no error creating entity, expected one: %+v", e)
-
-		ve, ok := err.(entity.ValidationError)
-		if !ok {
-			t.Errorf("error is type %T, expected entity.ValidationError", err)
-		} else if ve.Type != "cannot-set-metalabel" {
-			t.Errorf("entity.ValidationError.Type = %s, expected cannot-set-metalabel", ve.Type)
-		}
+		assertValidationError(t, err, "cannot-set-metalabel")
 	}
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_UPDATE)
 		require.Error(t, err, "no error creating entity, expected one: %+v", e)
-
-		ve, ok := err.(entity.ValidationError)
-		if !ok {
-			t.Errorf("error is type %T, expected entity.ValidationError", err)
-		} else if ve.Type != "cannot-change-metalabel" {
-			t.Errorf("entity.ValidationError.Type = %s, expected cannot-change-metalabel", ve.Type)
-		}
+		assertValidationError(t, err, "cannot-change-metalabel")
 	}
 }
 
 func TestValidateCreateEntitiesErrorsWhitespace(t *testing.T) {
 	invalid := []etre.Entity{
-		etre.Entity{" ": "b"},   // label can't be space
-		etre.Entity{" a": "b"},  // label can't have space
-		etre.Entity{" a ": "b"}, // label can't have space
-		etre.Entity{"a ": "b"},  // label can't have space
+		{" ": "b"},   // label can't be space
+		{" a": "b"},  // label can't have space
+		{" a ": "b"}, // label can't have space
+		{"a ": "b"},  // label can't have space
 	}
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_CREATE)
 		require.Error(t, err, "no error creating entity, expected one: %+v", e)
-
-		ve, ok := err.(entity.ValidationError)
-		if !ok {
-			t.Errorf("error is type %T, expected entity.ValidationError", err)
-		} else if ve.Type != "label-has-whitespace" {
-			t.Errorf("entity.ValidationError.Type = %s, expected label-has-whitespace", ve.Type)
-		}
+		assertValidationError(t, err, "label-has-whitespace")
 	}
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_UPDATE)
 		require.Error(t, err, "no error creating entity, expected one: %+v", e)
-
-		ve, ok := err.(entity.ValidationError)
-		if !ok {
-			t.Errorf("error is type %T, expected entity.ValidationError", err)
-		} else if ve.Type != "label-has-whitespace" {
-			t.Errorf("entity.ValidationError.Type = %s, expected label-has-whitespace", ve.Type)
-		}
+		assertValidationError(t, err, "label-has-whitespace")
 	}
 
 	invalid = []etre.Entity{
-		etre.Entity{"": "b"}, // label can't be empty string
+		{"": "b"}, // label can't be empty string
 	}
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_CREATE)
 		require.Error(t, err, "no error creating entity, expected one: %+v", e)
-
-		ve, ok := err.(entity.ValidationError)
-		if !ok {
-			t.Errorf("error is type %T, expected entity.ValidationError", err)
-		} else if ve.Type != "empty-string-label" {
-			t.Errorf("entity.ValidationError.Type = %s, expected empty-string-label", ve.Type)
-		}
+		assertValidationError(t, err, "empty-string-label")
 	}
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_UPDATE)
 		require.Error(t, err, "no error creating entity, expected one: %+v", e)
-
-		ve, ok := err.(entity.ValidationError)
-		if !ok {
-			t.Errorf("error is type %T, expected entity.ValidationError", err)
-		} else if ve.Type != "empty-string-label" {
-			t.Errorf("entity.ValidationError.Type = %s, expected cannot-change-metalabel", ve.Type)
-		}
+		assertValidationError(t, err, "empty-string-label")
 	}
 }
 
@@ -124,14 +88,7 @@ func TestValidateWriteOpOK(t *testing.T) {
 	}
 	err := validate.WriteOp(wo)
 	require.Error(t, err)
-
-	v, ok := err.(entity.ValidationError)
-	if !ok {
-		t.Fatalf("err is type %#v, expected entity.ValidationError", err)
-	}
-	if v.Type != "invalid-entity-type" {
-		t.Errorf("Type = %s, expected invalid-entity-type", v.Type)
-	}
+	assertValidationError(t, err, "invalid-entity-type")
 }
 
 func TestValidateDeleteLabel(t *testing.T) {
@@ -139,4 +96,20 @@ func TestValidateDeleteLabel(t *testing.T) {
 	require.NoError(t, err)
 	err = validate.DeleteLabel("_id")
 	require.Error(t, err)
+}
+
+// assertValidationError asserts the error to be a non-nil ValidationError and asserts the expected type.
+func assertValidationError(t *testing.T, err error, expectedType string) {
+	// Ugly asserts and returns instead of require so that the test can continue
+	t.Helper()
+	assert.Error(t, err)
+	if err == nil {
+		return
+	}
+	ve, ok := err.(entity.ValidationError)
+	assert.True(t, ok)
+	if !ok {
+		return
+	}
+	assert.Equal(t, expectedType, ve.Type)
 }

--- a/entity/validate_test.go
+++ b/entity/validate_test.go
@@ -5,6 +5,9 @@ package entity_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/square/etre"
 	"github.com/square/etre/entity"
 )
@@ -18,9 +21,7 @@ func TestValidateCreateEntitiesOK(t *testing.T) {
 		etre.Entity{"y": 1},
 	}
 	err := validate.Entities(entities, entity.VALIDATE_ON_CREATE)
-	if err != nil {
-		t.Errorf("got err '%v', expected nil", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestValidateCreateEntitiesErrorsMetalabels(t *testing.T) {
@@ -32,9 +33,8 @@ func TestValidateCreateEntitiesErrorsMetalabels(t *testing.T) {
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_CREATE)
-		if err == nil {
-			t.Errorf("no error creating entity, expected one: %+v", e)
-		}
+		assert.Errorf(t, err, "no error creating entity, expected one: %+v", e)
+
 		ve, ok := err.(entity.ValidationError)
 		if !ok {
 			t.Errorf("error is type %T, expected entity.ValidationError", err)
@@ -45,9 +45,8 @@ func TestValidateCreateEntitiesErrorsMetalabels(t *testing.T) {
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_UPDATE)
-		if err == nil {
-			t.Errorf("no error creating entity, expected one: %+v", e)
-		}
+		require.Error(t, err, "no error creating entity, expected one: %+v", e)
+
 		ve, ok := err.(entity.ValidationError)
 		if !ok {
 			t.Errorf("error is type %T, expected entity.ValidationError", err)
@@ -67,9 +66,8 @@ func TestValidateCreateEntitiesErrorsWhitespace(t *testing.T) {
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_CREATE)
-		if err == nil {
-			t.Errorf("no error creating entity, expected one: %+v", e)
-		}
+		require.Error(t, err, "no error creating entity, expected one: %+v", e)
+
 		ve, ok := err.(entity.ValidationError)
 		if !ok {
 			t.Errorf("error is type %T, expected entity.ValidationError", err)
@@ -80,9 +78,8 @@ func TestValidateCreateEntitiesErrorsWhitespace(t *testing.T) {
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_UPDATE)
-		if err == nil {
-			t.Errorf("no error creating entity, expected one: %+v", e)
-		}
+		require.Error(t, err, "no error creating entity, expected one: %+v", e)
+
 		ve, ok := err.(entity.ValidationError)
 		if !ok {
 			t.Errorf("error is type %T, expected entity.ValidationError", err)
@@ -97,9 +94,8 @@ func TestValidateCreateEntitiesErrorsWhitespace(t *testing.T) {
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_CREATE)
-		if err == nil {
-			t.Errorf("no error creating entity, expected one: %+v", e)
-		}
+		require.Error(t, err, "no error creating entity, expected one: %+v", e)
+
 		ve, ok := err.(entity.ValidationError)
 		if !ok {
 			t.Errorf("error is type %T, expected entity.ValidationError", err)
@@ -110,9 +106,8 @@ func TestValidateCreateEntitiesErrorsWhitespace(t *testing.T) {
 
 	for _, e := range invalid {
 		err := validate.Entities([]etre.Entity{e}, entity.VALIDATE_ON_UPDATE)
-		if err == nil {
-			t.Errorf("no error creating entity, expected one: %+v", e)
-		}
+		require.Error(t, err, "no error creating entity, expected one: %+v", e)
+
 		ve, ok := err.(entity.ValidationError)
 		if !ok {
 			t.Errorf("error is type %T, expected entity.ValidationError", err)
@@ -128,9 +123,8 @@ func TestValidateWriteOpOK(t *testing.T) {
 		Caller:     "dn",
 	}
 	err := validate.WriteOp(wo)
-	if err == nil {
-		t.Fatal("err is nill, expected an enitty.ValidationError")
-	}
+	require.Error(t, err)
+
 	v, ok := err.(entity.ValidationError)
 	if !ok {
 		t.Fatalf("err is type %#v, expected entity.ValidationError", err)
@@ -142,11 +136,7 @@ func TestValidateWriteOpOK(t *testing.T) {
 
 func TestValidateDeleteLabel(t *testing.T) {
 	err := validate.DeleteLabel("foo")
-	if err != nil {
-		t.Errorf("got err '%v', expected nil", err)
-	}
+	require.NoError(t, err)
 	err = validate.DeleteLabel("_id")
-	if err == nil {
-		t.Fatal("err is nill, expected an enitty.ValidationError")
-	}
+	require.Error(t, err)
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-test/deep v1.1.1
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/gorilla/websocket v1.5.3
+	github.com/stretchr/testify v1.9.0
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag v1.16.4
 	go.mongodb.org/mongo-driver v1.17.1
@@ -19,6 +20,7 @@ require (
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/alexflint/go-scalar v1.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/swaggo/files v1.0.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/square/etre"
 	"github.com/square/etre/metrics"
 )
@@ -174,10 +176,7 @@ func TestEntityMetrics(t *testing.T) {
 		},
 	}
 	gotReport := em.Report(true)
-	if diff := deep.Equal(gotReport, expectReport); diff != nil {
-		dump(gotReport, t)
-		t.Error(diff)
-	}
+	assert.Equal(t, expectReport, gotReport)
 }
 
 func TestMultipleEntityMetrics(t *testing.T) {
@@ -226,10 +225,7 @@ func TestMultipleEntityMetrics(t *testing.T) {
 		},
 	}
 	gotReport := em.Report(true)
-	if diff := deep.Equal(gotReport, expectReport); diff != nil {
-		dump(gotReport, t)
-		t.Error(diff)
-	}
+	assert.Equal(t, expectReport, gotReport)
 }
 
 func TestSharedEntityMetrics(t *testing.T) {
@@ -288,15 +284,9 @@ func TestSharedEntityMetrics(t *testing.T) {
 		},
 	}
 	gotReport := em1.Report(false)
-	if diff := deep.Equal(gotReport, expectReport); diff != nil {
-		dump(gotReport, t)
-		t.Error(diff)
-	}
+	assert.Equal(t, expectReport, gotReport)
 	gotReport = em2.Report(false)
-	if diff := deep.Equal(gotReport, expectReport); diff != nil {
-		dump(gotReport, t)
-		t.Error(diff)
-	}
+	assert.Equal(t, expectReport, gotReport)
 }
 
 func TestMemoryStore(t *testing.T) {
@@ -328,35 +318,23 @@ func TestMemoryStore(t *testing.T) {
 		},
 	}
 	gotReport := em.Report(true)
-	if diff := deep.Equal(gotReport, expectReport); diff != nil {
-		dump(gotReport, t)
-		t.Error(diff)
-	}
+	assert.Equal(t, expectReport, gotReport)
 
 	s := metrics.NewMemoryStore()
 
 	// New store, shouldn't have the metrics yet
-	if m := s.Get("test"); m != nil {
-		t.Errorf("Get(test) returned non-nil, expected nil")
-	}
+	m := s.Get("test")
+	assert.Nil(t, m)
 
 	// Store, re-fetch, and ensure it has same values by checking reprot
-	if err := s.Add(gm, "test"); err != nil {
-		t.Error(err)
-	}
+	err := s.Add(gm, "test")
+	require.NoError(t, err)
 	gm2 := s.Get("test")
-	if gm2 == nil {
-		t.Fatal("Get(test) returned nil, expected Metrics")
-	}
+	assert.NotNil(t, gm2, "Get(test) returned nil, expected Metrics")
 	gotReport = gm2.Report(true)
-	if diff := deep.Equal(gotReport, expectReport); diff != nil {
-		dump(gotReport, t)
-		t.Error(diff)
-	}
+	assert.Equal(t, expectReport, gotReport)
 
 	gotNames := s.Names()
 	expectNames := []string{"test"}
-	if diff := deep.Equal(gotNames, expectNames); diff != nil {
-		t.Error(diff)
-	}
+	assert.Equal(t, expectNames, gotNames)
 }

--- a/query/kls_test.go
+++ b/query/kls_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre/query"
 )
@@ -14,9 +15,7 @@ func TestParseIn(t *testing.T) {
 	// Basic "x in (<values>)"
 	sel := "x in (1,2,3)"
 	got, err := query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect := []query.Requirement{
 		{
 			Label:  "x",
@@ -31,9 +30,7 @@ func TestParseIn(t *testing.T) {
 	// "in(<values>)": no space between "in" and value list
 	sel = "x in(1,2,3)"
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{
 		{
 			Label:  "x",
@@ -50,9 +47,7 @@ func TestParseNotIn(t *testing.T) {
 	// Basic "x notin (<values>)"
 	sel := "x notin (1,2,3)"
 	got, err := query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect := []query.Requirement{
 		{
 			Label:  "x",
@@ -67,9 +62,7 @@ func TestParseNotIn(t *testing.T) {
 	// "notin(<values>)": no space between "notin" and value list
 	sel = "x notin(1,2,3)"
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{
 		{
 			Label:  "x",
@@ -86,9 +79,7 @@ func TestParseEqual(t *testing.T) {
 	// Basic "x = 1"
 	sel := "x = 1"
 	got, err := query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect := []query.Requirement{
 		{
 			Label:  "x",
@@ -103,9 +94,7 @@ func TestParseEqual(t *testing.T) {
 	// "x=1": no spacing
 	sel = "x=1"
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{
 		{
 			Label:  "x",
@@ -120,9 +109,7 @@ func TestParseEqual(t *testing.T) {
 	// Basic "x == 1"
 	sel = "x == 1"
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{
 		{
 			Label:  "x",
@@ -137,9 +124,7 @@ func TestParseEqual(t *testing.T) {
 	// "x==1": no spacing
 	sel = "x==1"
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{
 		{
 			Label:  "x",
@@ -156,9 +141,7 @@ func TestParseNotEqual(t *testing.T) {
 	// Basic "x != 1"
 	sel := "x != 1"
 	got, err := query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect := []query.Requirement{
 		{
 			Label:  "x",
@@ -173,9 +156,7 @@ func TestParseNotEqual(t *testing.T) {
 	// "x!=1": no spacing
 	sel = "x!=1"
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{
 		{
 			Label:  "x",
@@ -194,9 +175,8 @@ func TestParseInequality(t *testing.T) {
 		// With space
 		sel := "x " + op + " 1"
 		got, err := query.Parse(sel)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		expect := []query.Requirement{
 			{
 				Label:  "x",
@@ -211,9 +191,8 @@ func TestParseInequality(t *testing.T) {
 		// No space
 		sel = "x" + op + "1"
 		got, err = query.Parse(sel)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		if diff := deep.Equal(got, expect); diff != nil {
 			t.Error(diff)
 		}
@@ -225,9 +204,7 @@ func TestParseMixed(t *testing.T) {
 	// equality, exists
 	sel := "x = y, z"
 	got, err := query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect := []query.Requirement{
 		{
 			Label:  "x",
@@ -247,9 +224,7 @@ func TestParseMixed(t *testing.T) {
 	// exists, exists, exists
 	sel = "x,y,z"
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{
 		{
 			Label:  "x",
@@ -274,9 +249,7 @@ func TestParseMixed(t *testing.T) {
 	// Everything
 	sel = "x in (1,2), y notin(stage), z = foo, foo!=bar, app == shift, p, !p"
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{
 		{
 			Label:  "x",
@@ -324,9 +297,7 @@ func TestParseExcessiveSpacing(t *testing.T) {
 	// Ignore spacing around everything
 	sel := "  x =    y  , z      "
 	got, err := query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect := []query.Requirement{
 		{
 			Label:  "x",
@@ -347,9 +318,8 @@ func TestParseExcessiveSpacing(t *testing.T) {
 	// auto-generated properly?
 	sel = "                      "
 	got, err = query.Parse(sel)
-	if err == nil {
-		t.Errorf("err is nil, expected an error")
-	}
+	require.Error(t, err)
+
 	if got != nil {
 		t.Errorf("got %+v, expected nil []Requirement", got)
 	}
@@ -358,9 +328,7 @@ func TestParseExcessiveSpacing(t *testing.T) {
 	// no requirements.
 	sel = ""
 	got, err = query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect = []query.Requirement{}
 	if diff := deep.Equal(got, expect); diff != nil {
 		t.Error(diff)
@@ -370,9 +338,7 @@ func TestParseExcessiveSpacing(t *testing.T) {
 func TestParseQueryId(t *testing.T) {
 	sel := "_id = 507f191e810c19729de860ea"
 	got, err := query.Parse(sel)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	expect := []query.Requirement{
 		{
 			Label:  "_id",
@@ -445,9 +411,8 @@ func TestParseValidLabels(t *testing.T) {
 	}
 	for _, sel := range invalid {
 		got, err := query.Parse(sel)
-		if err != nil {
-			t.Errorf("selector '%s' is valid but caused an error: %s", sel, err)
-		}
+		require.NoError(t, err, "selector '%s' is valid but caused an error: %s", sel, err)
+
 		if len(got) != 1 || len(got[0].Values) != 1 || got[0].Values[0] != "foo" {
 			t.Errorf("selector '%s' parsed wrong value: %+v", sel, got)
 		}

--- a/query/kls_test.go
+++ b/query/kls_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre/query"
@@ -23,9 +24,8 @@ func TestParseIn(t *testing.T) {
 			Values: []string{"1", "2", "3"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff := deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// "in(<values>)": no space between "in" and value list
 	sel = "x in(1,2,3)"
@@ -38,9 +38,8 @@ func TestParseIn(t *testing.T) {
 			Values: []string{"1", "2", "3"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 }
 
 func TestParseNotIn(t *testing.T) {
@@ -55,9 +54,8 @@ func TestParseNotIn(t *testing.T) {
 			Values: []string{"1", "2", "3"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff := deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// "notin(<values>)": no space between "notin" and value list
 	sel = "x notin(1,2,3)"
@@ -70,9 +68,9 @@ func TestParseNotIn(t *testing.T) {
 			Values: []string{"1", "2", "3"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
+
 }
 
 func TestParseEqual(t *testing.T) {
@@ -87,9 +85,8 @@ func TestParseEqual(t *testing.T) {
 			Values: []string{"1"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff := deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// "x=1": no spacing
 	sel = "x=1"
@@ -102,9 +99,8 @@ func TestParseEqual(t *testing.T) {
 			Values: []string{"1"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// Basic "x == 1"
 	sel = "x == 1"
@@ -117,9 +113,8 @@ func TestParseEqual(t *testing.T) {
 			Values: []string{"1"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// "x==1": no spacing
 	sel = "x==1"
@@ -132,9 +127,9 @@ func TestParseEqual(t *testing.T) {
 			Values: []string{"1"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
+
 }
 
 func TestParseNotEqual(t *testing.T) {
@@ -149,9 +144,8 @@ func TestParseNotEqual(t *testing.T) {
 			Values: []string{"1"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff := deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// "x!=1": no spacing
 	sel = "x!=1"
@@ -164,9 +158,8 @@ func TestParseNotEqual(t *testing.T) {
 			Values: []string{"1"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 }
 
 func TestParseInequality(t *testing.T) {
@@ -184,18 +177,16 @@ func TestParseInequality(t *testing.T) {
 				Values: []string{"1"},
 			},
 		}
-		if diff := deep.Equal(got, expect); diff != nil {
-			t.Error(diff)
-		}
+		diff := deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+		assert.Nil(t, diff)
 
 		// No space
 		sel = "x" + op + "1"
 		got, err = query.Parse(sel)
 		require.NoError(t, err)
 
-		if diff := deep.Equal(got, expect); diff != nil {
-			t.Error(diff)
-		}
+		diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+		assert.Nil(t, diff)
 	}
 }
 
@@ -217,9 +208,8 @@ func TestParseMixed(t *testing.T) {
 			Values: nil,
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff := deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// exists, exists, exists
 	sel = "x,y,z"
@@ -242,9 +232,8 @@ func TestParseMixed(t *testing.T) {
 			Values: nil,
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// Everything
 	sel = "x in (1,2), y notin(stage), z = foo, foo!=bar, app == shift, p, !p"
@@ -287,13 +276,11 @@ func TestParseMixed(t *testing.T) {
 			Values: nil,
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 }
 
 func TestParseExcessiveSpacing(t *testing.T) {
-
 	// Ignore spacing around everything
 	sel := "  x =    y  , z      "
 	got, err := query.Parse(sel)
@@ -310,19 +297,15 @@ func TestParseExcessiveSpacing(t *testing.T) {
 			Values: nil,
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff := deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 
 	// Nothing but space is an error. It could mean the query wasn't
 	// auto-generated properly?
 	sel = "                      "
 	got, err = query.Parse(sel)
 	require.Error(t, err)
-
-	if got != nil {
-		t.Errorf("got %+v, expected nil []Requirement", got)
-	}
+	assert.Nil(t, got)
 
 	// An empty string is not an error. It could imply "everything", i.e.
 	// no requirements.
@@ -330,9 +313,8 @@ func TestParseExcessiveSpacing(t *testing.T) {
 	got, err = query.Parse(sel)
 	require.NoError(t, err)
 	expect = []query.Requirement{}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff = deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 }
 
 func TestParseQueryId(t *testing.T) {
@@ -346,9 +328,8 @@ func TestParseQueryId(t *testing.T) {
 			Values: []string{"507f191e810c19729de860ea"},
 		},
 	}
-	if diff := deep.Equal(got, expect); diff != nil {
-		t.Error(diff)
-	}
+	diff := deep.Equal(got, expect) // can't use assert.Equal because some unexported fields don't match. deep.Equal only compares exported fields.
+	assert.Nil(t, diff)
 }
 
 func TestParseInvalid(t *testing.T) {
@@ -385,9 +366,8 @@ func TestParseInvalid(t *testing.T) {
 		`label\name=val`,
 	}
 	for _, sel := range invalid {
-		if got, err := query.Parse(sel); err == nil {
-			t.Errorf("selector '%s' is invalid but did not cause an error: %+v", sel, got)
-		}
+		got, err := query.Parse(sel)
+		assert.Error(t, err, "selector '%s' is invalid but did not cause an error: %s", sel, got)
 	}
 }
 
@@ -412,9 +392,6 @@ func TestParseValidLabels(t *testing.T) {
 	for _, sel := range invalid {
 		got, err := query.Parse(sel)
 		require.NoError(t, err, "selector '%s' is valid but caused an error: %s", sel, err)
-
-		if len(got) != 1 || len(got[0].Values) != 1 || got[0].Values[0] != "foo" {
-			t.Errorf("selector '%s' parsed wrong value: %+v", sel, got)
-		}
+		assert.True(t, len(got) == 1 && len(got[0].Values) == 1 && got[0].Values[0] == "foo", "selector '%s' parsed wrong value: %+v", sel, got)
 	}
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -5,7 +5,7 @@ package query_test
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/square/etre/query"
 )
@@ -97,11 +97,9 @@ func TestQueryTranslate(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		got, err := query.Translate(tc.query)
-		if tc.returnsError && err == nil {
-			t.Errorf("query '%s' should return an error but didn't", tc.query)
+		if tc.returnsError {
+			assert.Error(t, err, "query '%s' should return an error but didn't", tc.query)
 		}
-		if diff := deep.Equal(got, tc.expect); diff != nil {
-			t.Errorf("query '%s': %v", tc.query, diff)
-		}
+		assert.Equal(t, tc.expect, got, "query '%s'", tc.query)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
 
@@ -40,9 +41,7 @@ func TestDBPlugin(t *testing.T) {
 	require.NoError(t, err, "Error booting server")
 
 	// Check that the DB plugin was called twice: once for the main DB and once for the CDC DB.
-	if counter != 2 {
-		t.Errorf("Expected DB plugin to be called twice, but got %d", counter)
-	}
+	assert.Equal(t, 2, counter, "Expected DB plugin to be called twice")
 
 	// Stop the server
 	err = s.Stop()

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/square/etre/app"
@@ -15,13 +16,10 @@ import (
 func TestDefaultPlugins(t *testing.T) {
 	s := NewServer(app.Defaults())
 	err := s.Boot("../test/config/empty.yaml")
-	if err != nil {
-		t.Fatalf("Error booting server: %s", err)
-	}
+	require.NoError(t, err, "Error booting server")
+
 	err = s.Stop()
-	if err != nil {
-		t.Fatalf("Error stopping server: %s", err)
-	}
+	require.NoError(t, err, "Error stopping server")
 }
 
 // TestDBPlugin tests server boot with a DB plugin
@@ -39,9 +37,8 @@ func TestDBPlugin(t *testing.T) {
 	s := NewServer(ctx)
 	// Start the server
 	err := s.Boot("../test/config/empty.yaml")
-	if err != nil {
-		t.Fatalf("Error booting server: %s", err)
-	}
+	require.NoError(t, err, "Error booting server")
+
 	// Check that the DB plugin was called twice: once for the main DB and once for the CDC DB.
 	if counter != 2 {
 		t.Errorf("Expected DB plugin to be called twice, but got %d", counter)
@@ -49,7 +46,5 @@ func TestDBPlugin(t *testing.T) {
 
 	// Stop the server
 	err = s.Stop()
-	if err != nil {
-		t.Fatalf("Error stopping server: %s", err)
-	}
+	require.NoError(t, err, "Error stopping server")
 }


### PR DESCRIPTION
There should be no logical changes in this PR. Only updates to tests to use assert and require instead of if blocks. 

Redundant error messages from t.Error / t.Fatal were removed in cases where assert and require generate appropriate errors messages. For example, assert.Equals does not need an error message to show the expected and actual values, since those are included in the default failure message.