### PR TITLE
Fix CDC and metrics handling

### DIFF
--- a/api/api_gomux.go
+++ b/api/api_gomux.go
@@ -468,7 +468,7 @@ func (api *API) cdcWrapper(next http.Handler) http.Handler {
 		// Authorize
 		// --------------------------------------------------------------
 
-		if err := api.auth.Authorize(caller, auth.Action{Op: auth.OP_READ}); err != nil {
+		if err := api.auth.Authorize(caller, auth.Action{Op: auth.OP_CDC}); err != nil {
 			log.Printf("AUTH: not authorized: %s (caller: %+v request: %+v)", err, caller, r)
 			gm.Inc(metrics.AuthorizationFailed, 1)
 			authErr := auth.Error{

--- a/api/api_gomux.go
+++ b/api/api_gomux.go
@@ -129,7 +129,7 @@ func NewAPI(appCtx app.Context) *API {
 	// /////////////////////////////////////////////////////////////////////
 	// Changes
 	// /////////////////////////////////////////////////////////////////////
-	mux.Handle("GET "+etre.API_ROOT+"/changes", api.requestWrapper(http.HandlerFunc(api.changesHandler)))
+	mux.Handle("GET "+etre.API_ROOT+"/changes", api.cdcWrapper(http.HandlerFunc(api.changesHandler)))
 
 	// /////////////////////////////////////////////////////////////////////
 	// OpenAPI docs
@@ -176,16 +176,32 @@ func (api *API) Stop() error {
 	return api.srv.Shutdown(context.TODO())
 }
 
+// requestWrapper adds auth and metrics middleware to the endpoint handler for
+// entity read/write endpoints. CDC should use cdcWrapper instead.
 func (api *API) requestWrapper(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		write := isWriteRequest(r.Method)
-		cdc := strings.HasSuffix(r.URL.String(), "/changes")
 
 		// Etre request context passed to endpoint handler
 		rc := &req{
 			entityType: r.PathValue("type"),
 			write:      write,
+		}
+
+		// requests passed to requestWrapper should always have an entity type
+		if rc.entityType == "" {
+			etreErr := etre.Error{
+				Message:    "missing entity type in request path: " + r.URL.String(),
+				Type:       "bad-request",
+				HTTPStatus: http.StatusBadRequest,
+			}
+			if write {
+				api.WriteResult(rc, w, nil, etreErr)
+			} else {
+				api.readError(rc, w, etreErr)
+			}
+			return
 		}
 
 		defer func() {
@@ -284,22 +300,20 @@ func (api *API) requestWrapper(next http.Handler) http.Handler {
 		gm := api.metricsFactory.Make(caller.MetricGroups)
 		rc.gm = gm
 
-		if rc.entityType != "" {
-			if err := api.validate.EntityType(rc.entityType); err != nil {
-				log.Printf("Invalid entity type: '%s': caller=%+v request=%+v", rc.entityType, caller, r)
-				gm.Inc(metrics.InvalidEntityType, 1)
-				if write {
-					api.WriteResult(rc, w, nil, err)
-				} else {
-					api.readError(rc, w, err)
-				}
-				return
+		if err := api.validate.EntityType(rc.entityType); err != nil {
+			log.Printf("Invalid entity type: '%s': caller=%+v request=%+v", rc.entityType, caller, r)
+			gm.Inc(metrics.InvalidEntityType, 1)
+			if write {
+				api.WriteResult(rc, w, nil, err)
+			} else {
+				api.readError(rc, w, err)
 			}
-
-			// Bind group metrics to entity type
-			gm.EntityType(rc.entityType)
-			gm.Inc(metrics.Query, 1) // all queries (QPS)
+			return
 		}
+
+		// Bind group metrics to entity type
+		gm.EntityType(rc.entityType)
+		gm.Inc(metrics.Query, 1) // all queries (QPS)
 
 		// auth.Manager extracts trace values from X-Etre-Trace header
 		if caller.Trace != nil {
@@ -309,13 +323,6 @@ func (api *API) requestWrapper(next http.Handler) http.Handler {
 		// --------------------------------------------------------------
 		// Authorize
 		// --------------------------------------------------------------
-
-		// Authorize any endpoint with an entity type or CDC; do not authorize
-		// other endpoints like metrics, status, and docs
-		authorize := rc.entityType != "" || cdc
-		if !authorize {
-			goto handler
-		}
 
 		rc.inst.Start("authorize")
 		if write {
@@ -369,16 +376,11 @@ func (api *API) requestWrapper(next http.Handler) http.Handler {
 		// Endpoint
 		// //////////////////////////////////////////////////////////////////////
 
-	handler:
 		next.ServeHTTP(w, r.WithContext(context.WithValue(ctx, reqKey, rc)))
 
 		// //////////////////////////////////////////////////////////////////////
 		// After
 		// //////////////////////////////////////////////////////////////////////
-
-		if cdc { // no query time for CDC cilents; they're not queries
-			return
-		}
 
 		// Record query latency (response time) in milliseconds
 		queryLatency := time.Now().Sub(t0)
@@ -396,6 +398,93 @@ func (api *API) requestWrapper(next http.Handler) http.Handler {
 		if rc.inst != app.NopInstrument && queryLatency > api.queryProfReportThreshold {
 			log.Printf("Query profile: %s %s %s %+v (caller=%+v)", r.Method, r.URL.String(), queryLatency, rc.inst.Report(), caller)
 		}
+	})
+}
+
+// cdcWrapper auth and metrics middleware for the changes endpoint. This endpoint is
+// unique because it does not have an entity type and is a long-lived connection that
+// should not use query timeout and long running query instrumentation.
+func (api *API) cdcWrapper(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// Etre request context passed to endpoint handler
+		rc := &req{}
+
+		defer func() {
+			if r := recover(); r != nil {
+				err, ok := r.(error)
+				if !ok {
+					err = fmt.Errorf("%v", r)
+				}
+				b := make([]byte, 4096)
+				n := runtime.Stack(b, false)
+				etreErr := etre.Error{
+					Message:    fmt.Sprintf("PANIC: %s\n%s", err, string(b[0:n])),
+					Type:       "panic",
+					HTTPStatus: http.StatusInternalServerError,
+				}
+				log.Printf("PANIC: %s\n%s\n\n", err, string(b[0:n]))
+				api.readError(rc, w, etreErr)
+			}
+		}()
+
+		api.systemMetrics.Inc(metrics.Load, 1)
+		defer api.systemMetrics.Inc(metrics.Load, -1)
+
+		api.systemMetrics.Inc(metrics.Query, 1)
+
+		// --------------------------------------------------------------
+		// Authenticate
+		// --------------------------------------------------------------
+		caller, err := api.auth.Authenticate(r)
+		if err != nil {
+			log.Printf("AUTH: failed to authenticate: %s (caller: %+v request: %+v)", err, caller, r)
+			api.systemMetrics.Inc(metrics.AuthenticationFailed, 1)
+			authErr := auth.Error{
+				Err:        err,
+				Type:       "access-denied",
+				HTTPStatus: http.StatusUnauthorized,
+			}
+			api.readError(rc, w, authErr)
+			return
+		}
+		rc.caller = caller
+
+		// --------------------------------------------------------------
+		// Metrics
+		// --------------------------------------------------------------
+
+		// This makes a metrics.Group which is a 1-to-many proxy for every
+		// metric group in caller.MetricGroups. E.g. if the groups are "ods"
+		// and "finch", then every metric is recorded in both groups.
+		//
+		// Note that CDC does not have an entity type, so entity type specific
+		// metrics should not be recorded.
+		gm := api.metricsFactory.Make(caller.MetricGroups)
+		rc.gm = gm
+
+		// --------------------------------------------------------------
+		// Authorize
+		// --------------------------------------------------------------
+
+		if err := api.auth.Authorize(caller, auth.Action{Op: auth.OP_READ}); err != nil {
+			log.Printf("AUTH: not authorized: %s (caller: %+v request: %+v)", err, caller, r)
+			gm.Inc(metrics.AuthorizationFailed, 1)
+			authErr := auth.Error{
+				Err:        err,
+				Type:       "not-authorized",
+				HTTPStatus: http.StatusForbidden,
+			}
+			api.readError(rc, w, authErr)
+			return
+		}
+
+		// //////////////////////////////////////////////////////////////////////
+		// Endpoint
+		// //////////////////////////////////////////////////////////////////////
+
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), reqKey, rc)))
 	})
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -44,7 +44,7 @@ type server struct {
 	api             *api.API
 	ts              *httptest.Server
 	url             string
-	auth            *mock.AuthPlugin
+	auth            *mock.AuthRecorder
 	cdcStore        *mock.CDCStore
 	streamerFactory *mock.StreamerFactory
 	metricsrec      *mock.MetricRecorder
@@ -86,7 +86,7 @@ func setup(t *testing.T, cfg config.Config, store mock.EntityStore) *server {
 	server := &server{
 		store:           store,
 		cfg:             cfg,
-		auth:            &mock.AuthPlugin{},
+		auth:            &mock.AuthRecorder{},
 		cdcStore:        &mock.CDCStore{},
 		streamerFactory: &mock.StreamerFactory{},
 		metricsrec:      mock.NewMetricsRecorder(),

--- a/api/bulk_write_test.go
+++ b/api/bulk_write_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
+	"github.com/square/etre/auth"
 	"github.com/square/etre/entity"
 	"github.com/square/etre/metrics"
 	"github.com/square/etre/query"
@@ -60,7 +61,7 @@ func TestPostEntitiesOK(t *testing.T) {
 	assert.Equal(t, expectWR, gotWR)
 
 	expectWO := entity.WriteOp{
-		Caller:     "test", // from mock.AuthPlugin
+		Caller:     "test", // from mock.AuthRecorder
 		EntityType: entityType,
 	}
 	assert.Equal(t, expectWO, gotWO)
@@ -78,6 +79,13 @@ func TestPostEntitiesOK(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestPostEntitiesErrors(t *testing.T) {
@@ -278,7 +286,7 @@ func TestPutEntitiesOK(t *testing.T) {
 	assert.Equal(t, expectWR, gotWR)
 
 	expectWO := entity.WriteOp{
-		Caller:     "test", // from mock.AuthPlugin
+		Caller:     "test", // from mock.AuthRecorder
 		EntityType: entityType,
 	}
 	assert.Equal(t, expectWO, gotWO)
@@ -302,6 +310,13 @@ func TestPutEntitiesOK(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestPutEntitiesErrors(t *testing.T) {
@@ -513,7 +528,7 @@ func TestDeleteEntitiesOK(t *testing.T) {
 	assert.Equal(t, expectWR, gotWR)
 
 	expectWO := entity.WriteOp{
-		Caller:     "test", // from mock.AuthPlugin
+		Caller:     "test", // from mock.AuthRecorder
 		EntityType: entityType,
 	}
 	assert.Equal(t, expectWO, gotWO)
@@ -534,6 +549,13 @@ func TestDeleteEntitiesOK(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestDeleteEntitiesErrors(t *testing.T) {

--- a/api/changes_test.go
+++ b/api/changes_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/square/etre"
+	"github.com/square/etre/auth"
 	"github.com/square/etre/cdc/changestream"
 	"github.com/square/etre/test/mock"
 )
@@ -84,6 +85,13 @@ func TestChanges(t *testing.T) {
 
 	assert.Equal(t, mock.CDCEvents[0:1], events)
 	assert.Equal(t, int64(0), gotSinceTs)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_CDC, EntityType: ""}, // no entity type for CDC
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 
 	/*
 		@todo Fix data race

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
+	"github.com/square/etre/auth"
 	"github.com/square/etre/entity"
 	"github.com/square/etre/metrics"
 	"github.com/square/etre/query"
@@ -67,10 +68,18 @@ func TestQueryBasic(t *testing.T) {
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_READ, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
+
 	// ----------------------------------------------------------------------
 	// Multi-label query
 	// ----------------------------------------------------------------------
 	server.metricsrec.Reset()
+	server.auth.Reset()
 
 	q = "host=local,env=production"
 	etreurl = server.url + etre.API_ROOT + "/entities/" + entityType +
@@ -103,10 +112,18 @@ func TestQueryBasic(t *testing.T) {
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_READ, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
+
 	// ----------------------------------------------------------------------
 	// Single-label exists query
 	// ----------------------------------------------------------------------
 	server.metricsrec.Reset()
+	server.auth.Reset()
 
 	q = "active"
 	etreurl = server.url + etre.API_ROOT + "/entities/" + entityType +
@@ -136,6 +153,13 @@ func TestQueryBasic(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_READ, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestQueryNoMatches(t *testing.T) {

--- a/api/single_entity_read_test.go
+++ b/api/single_entity_read_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
+	"github.com/square/etre/auth"
 	"github.com/square/etre/entity"
 	"github.com/square/etre/metrics"
 	"github.com/square/etre/query"
@@ -66,6 +67,13 @@ func TestGetEntityBasic(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_READ, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestGetEntityReturnLabels(t *testing.T) {
@@ -105,6 +113,13 @@ func TestGetEntityReturnLabels(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_READ, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestGetEntityNotFound(t *testing.T) {
@@ -272,4 +287,11 @@ func TestGetEntityLabels(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_READ, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }

--- a/api/single_entity_write_test.go
+++ b/api/single_entity_write_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/square/etre"
 	"github.com/square/etre/api"
+	"github.com/square/etre/auth"
 	"github.com/square/etre/entity"
 	"github.com/square/etre/metrics"
 	"github.com/square/etre/query"
@@ -63,7 +64,7 @@ func TestPostEntityOK(t *testing.T) {
 	assert.Equal(t, expectWR, gotWR)
 
 	expectWO := entity.WriteOp{
-		Caller:     "test", // from mock.AuthPlugin
+		Caller:     "test", // from mock.AuthRecorder
 		EntityType: entityType,
 	}
 	assert.Equal(t, expectWO, gotWO)
@@ -81,6 +82,13 @@ func TestPostEntityOK(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestPostEntityDuplicate(t *testing.T) {
@@ -121,6 +129,13 @@ func TestPostEntityDuplicate(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestPostEntityErrors(t *testing.T) {
@@ -275,7 +290,7 @@ func TestPutEntityOK(t *testing.T) {
 	assert.Equal(t, expectWR, gotWR)
 
 	expectWO := entity.WriteOp{
-		Caller:     "test", // from mock.AuthPlugin
+		Caller:     "test", // from mock.AuthRecorder
 		EntityType: entityType,
 		EntityId:   testEntityIds[0],
 	}
@@ -295,6 +310,13 @@ func TestPutEntityOK(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestPutEntityDuplicate(t *testing.T) {
@@ -338,6 +360,13 @@ func TestPutEntityDuplicate(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 func TestPutEntityNotFound(t *testing.T) {
@@ -591,7 +620,7 @@ func TestDeleteEntityOK(t *testing.T) {
 	assert.Equal(t, expectWR, gotWR)
 
 	expectWO := entity.WriteOp{
-		Caller:     "test", // from mock.AuthPlugin
+		Caller:     "test", // from mock.AuthRecorder
 		EntityType: entityType,
 		EntityId:   testEntityIds[0],
 	}
@@ -610,6 +639,13 @@ func TestDeleteEntityOK(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }
 
 // //////////////////////////////////////////////////////////////////////////
@@ -656,7 +692,7 @@ func TestDeleteLabel(t *testing.T) {
 	assert.Equal(t, expectWR, gotWR)
 
 	expectWO := entity.WriteOp{
-		Caller:     "test", // from mock.AuthPlugin
+		Caller:     "test", // from mock.AuthRecorder
 		EntityType: entityType,
 		EntityId:   testEntityIds[0],
 	}
@@ -676,4 +712,11 @@ func TestDeleteLabel(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
+
+	// -- Auth -----------------------------------------------------------
+	require.Len(t, server.auth.AuthenticateArgs, 1)
+	assert.Equal(t, []mock.AuthorizeArgs{{
+		Action: auth.Action{Op: auth.OP_WRITE, EntityType: entityType},
+		Caller: auth.Caller{Name: "test", MetricGroups: []string{"test"}},
+	}}, server.auth.AuthorizeArgs)
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -27,6 +27,9 @@ type ACL struct {
 	// Write entity types granted to the role. Does not apply to admin roles.
 	Write []string
 
+	// Role grants access to CDC events for all entity types.
+	CDC bool
+
 	// Trace keys required to be set. Applies to admin roles.
 	TraceKeysRequired []string
 }
@@ -50,6 +53,7 @@ type Action struct {
 const (
 	OP_READ  = "r"
 	OP_WRITE = "w"
+	OP_CDC   = "c"
 )
 
 // Plugin is the auth plugin. Implement this interface to enable custom auth.

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -48,6 +48,7 @@ func TestManager(t *testing.T) {
 			Role:  "bar",
 			Read:  []string{"bar", "foo"},
 			Write: []string{"bar"},
+			CDC:   true,
 		},
 		{
 			Role:              "foo",
@@ -141,6 +142,23 @@ func TestManager(t *testing.T) {
 
 	err = man.Authorize(caller, auth.Action{EntityType: "any-entity-type", Op: auth.OP_WRITE})
 	require.NoError(t, err)
+
+	// CDC authorization
+	// ---------------------------------------------------------------------------
+
+	// finch and bar have CDC access
+	caller.Roles = []string{"finch"}
+	err = man.Authorize(caller, auth.Action{Op: auth.OP_CDC})
+	require.NoError(t, err)
+
+	caller.Roles = []string{"bar"}
+	err = man.Authorize(caller, auth.Action{Op: auth.OP_CDC})
+	require.NoError(t, err)
+
+	// foo does not have CDC access
+	caller.Roles = []string{"foo"}
+	err = man.Authorize(caller, auth.Action{Op: auth.OP_CDC})
+	require.Error(t, err)
 }
 
 func TestManagerNoACLs(t *testing.T) {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -58,7 +58,7 @@ func TestManager(t *testing.T) {
 	}
 	var caller auth.Caller
 	var authErr, authorErr error
-	plugin := mock.AuthPlugin{
+	plugin := &mock.AuthRecorder{
 		AuthenticateFunc: func(req *http.Request) (auth.Caller, error) {
 			return caller, authErr
 		},
@@ -167,7 +167,7 @@ func TestManagerNoACLs(t *testing.T) {
 	// trace keys and Authorize just calls the plugin Authorize.
 	var caller auth.Caller
 	var authorizeCalled bool
-	plugin := mock.AuthPlugin{
+	plugin := &mock.AuthRecorder{
 		AuthenticateFunc: func(req *http.Request) (auth.Caller, error) {
 			return caller, nil
 		},
@@ -199,7 +199,7 @@ func TestManagerAuthenticateError(t *testing.T) {
 	}
 	var caller auth.Caller
 	var authErr error
-	plugin := mock.AuthPlugin{
+	plugin := &mock.AuthRecorder{
 		AuthenticateFunc: func(req *http.Request) (auth.Caller, error) {
 			return caller, authErr
 		},
@@ -255,7 +255,7 @@ func TestTraceHeader(t *testing.T) {
 		Name:  "foo",
 		Trace: map[string]string{"app": "do-not-change"},
 	}
-	p2 := mock.AuthPlugin{
+	p2 := &mock.AuthRecorder{
 		AuthenticateFunc: func(req *http.Request) (auth.Caller, error) {
 			return caller, nil
 		},

--- a/auth/manager.go
+++ b/auth/manager.go
@@ -85,6 +85,7 @@ func (m Manager) Authorize(caller Caller, a Action) error {
 	// Check each caller role against configured role ACLs
 	allowed := false
 	opName := ""
+roles:
 	for _, role := range caller.Roles {
 		acl := m.acl[role]
 		// Allow if admin role
@@ -101,6 +102,13 @@ func (m Manager) Authorize(caller Caller, a Action) error {
 		case OP_WRITE:
 			allowedEntityTypes = acl.Write
 			opName = "writing"
+		case OP_CDC:
+			opName = "CDC"
+			if acl.CDC {
+				allowed = true
+				break roles
+			}
+			continue roles // skip the inList check for CDC
 		}
 		if inList(a.EntityType, allowedEntityTypes) {
 			allowed = true

--- a/metrics/group.go
+++ b/metrics/group.go
@@ -437,8 +437,8 @@ func (m *groupEntityMetrics) IncLabel(mn byte, label string) {
 func (m *groupEntityMetrics) getLabelMetrics(label string) *labelMetrics {
 	m.Lock()
 	defer m.Unlock()
-	lm := m.em.label[label]
-	if lm == nil {
+	lm, ok := m.em.label[label]
+	if !ok {
 		lm = &labelMetrics{
 			Read:   gm.NewCounter(),
 			Update: gm.NewCounter(),

--- a/metrics/group_test.go
+++ b/metrics/group_test.go
@@ -1,0 +1,65 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMutexUnlock ensures that the mutex is released after a panic in groupEntityMetrics
+func TestMutexUnlock(t *testing.T) {
+	// IncLabel
+	gem := groupEntityMetrics{groupMetrics: NewGroupMetrics()}
+	doPanic(t, func() {
+		gem.IncLabel(Query, "foo") // will panic because we never called EntityType first
+	})
+	assert.True(t, gem.TryLock(), "groupEntityMetrics lock was not released after the panic")
+
+	// Trace
+	gem = groupEntityMetrics{groupMetrics: NewGroupMetrics()}
+	doPanic(t, func() {
+		gem.Trace(map[string]string{"k": "v"}) // will panic because we never called EntityType first
+	})
+	assert.True(t, gem.TryLock(), "groupEntityMetrics lock was not released after the panic")
+
+	// Inc
+	gem = groupEntityMetrics{groupMetrics: NewGroupMetrics()}
+	doPanic(t, func() {
+		gem.Inc(Read, 1) // will panic because we never called EntityType first
+	})
+	assert.True(t, gem.TryLock(), "groupEntityMetrics lock was not released after the panic")
+
+	// Val
+	gem = groupEntityMetrics{groupMetrics: NewGroupMetrics()}
+	doPanic(t, func() {
+		gem.Val(Read, 1) // will panic because we never called EntityType first
+	})
+	assert.True(t, gem.TryLock(), "groupEntityMetrics lock was not released after the panic")
+
+	// Report
+	gem = groupEntityMetrics{groupMetrics: NewGroupMetrics()}
+	doPanic(t, func() {
+		gem.entity = map[string]*entityMetrics{"k": nil} // need this to trigger a panic in report
+		gem.Report(false)
+	})
+	assert.True(t, gem.TryLock(), "groupEntityMetrics lock was not released after the panic")
+
+	// Report
+	gem = groupEntityMetrics{groupMetrics: NewGroupMetrics()}
+	doPanic(t, func() {
+		gem.entity = nil // need this to trigger a panic in report
+		gem.EntityType("foo")
+	})
+	assert.True(t, gem.TryLock(), "groupEntityMetrics lock was not released after the panic")
+}
+
+func doPanic(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			// This is expected
+		}
+	}()
+	f()
+	require.Fail(t, "Expected panic but did not get one")
+}

--- a/test/mock/auth.go
+++ b/test/mock/auth.go
@@ -8,23 +8,41 @@ import (
 	"github.com/square/etre/auth"
 )
 
-var _ auth.Plugin = AuthPlugin{}
+var _ auth.Plugin = &AuthRecorder{}
 
-type AuthPlugin struct {
+type AuthRecorder struct {
 	AuthenticateFunc func(*http.Request) (auth.Caller, error)
 	AuthorizeFunc    func(auth.Caller, auth.Action) error
+	AuthenticateArgs []AuthenticateArgs
+	AuthorizeArgs    []AuthorizeArgs
 }
 
-func (a AuthPlugin) Authenticate(req *http.Request) (auth.Caller, error) {
+type AuthenticateArgs struct {
+	Req *http.Request
+}
+
+type AuthorizeArgs struct {
+	Caller auth.Caller
+	Action auth.Action
+}
+
+func (a *AuthRecorder) Authenticate(req *http.Request) (auth.Caller, error) {
+	a.AuthenticateArgs = append(a.AuthenticateArgs, AuthenticateArgs{Req: req})
 	if a.AuthenticateFunc != nil {
 		return a.AuthenticateFunc(req)
 	}
 	return auth.Caller{Name: "test", MetricGroups: []string{"test"}}, nil
 }
 
-func (a AuthPlugin) Authorize(c auth.Caller, ac auth.Action) error {
+func (a *AuthRecorder) Authorize(c auth.Caller, ac auth.Action) error {
+	a.AuthorizeArgs = append(a.AuthorizeArgs, AuthorizeArgs{Caller: c, Action: ac})
 	if a.AuthorizeFunc != nil {
 		return a.AuthorizeFunc(c, ac)
 	}
 	return nil
+}
+
+func (a *AuthRecorder) Reset() {
+	a.AuthenticateArgs = []AuthenticateArgs{}
+	a.AuthorizeArgs = []AuthorizeArgs{}
 }


### PR DESCRIPTION
This includes multiple related fixes for an issue with CDC and metrics. CDC does not have an entity type as it fetches changes for all entities. Certain metrics require an EntityType and can panic if called without one. When CDC was called with trace data included, this panic could occur while holding a mutex lock, which caused the lock to never be released.

There are three fixes in this PR detailed below:

1) API tests now use real metrics

We had a bug which caused a panic in the metrics collector. The API tests only used mock metrics which did not trigger the same panic, hiding the bug. This change updates the API tests to call the real metrics implementation, which now exposes teh bug.

2) Prevent metrics panic from holding lock

If IncLabel or Trace are called without first calling EntityType, they will panic because the groupEntityMetrics.em is nil. Previously this panic would occur while holding m.Lock, causing the lock to never be released and blocking all future metrics calls.

Now we always defer m.Unlock(), so that even if there is a panic, we are certain to release the lock.

3) Change wrapper handling for CDC

CDC requests previously went through requestWrapper(...). This function adds middleware, but was complicated because CDC does not use the same middleware as a regular read/write request. In particular, CDC should not have request timeouts (since CDC connections are long lived) and do not have EntityType. For this reason it was cleaner to split the CDC middleware into its own cdcWrapper handler.

Auth for CDC also had to be updated. In older etre releases, CDC bypassed the authorization flow. To run CDC through authorization, we added a new operation OP_CDC to the auth package along with a boolean CDC flag in the ACL. This will require existing ACLs to be updated to allow CDC, but was cleaner than other options such as allowing CDC if the user had READ access to all known types. It also allows for users that can execute READ requests, but cannot stream CDC changes.