### PR TITLE
Fix configuration ACLs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -237,6 +237,7 @@ type ACL struct {
 	Admin             bool     `yaml:"admin"`
 	Read              []string `yaml:"read"`
 	Write             []string `yaml:"write"`
+	CDC               bool     `yaml:"cdc"`
 	TraceKeysRequired []string `yaml:"trace_keys_required"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -80,3 +80,27 @@ func TestLoadTest002(t *testing.T) {
 	expect.CDC.Disabled = true // testing this
 	assert.Equal(t, expect, got)
 }
+
+func TestLoadTestACL(t *testing.T) {
+	got, err := config.Load("../test/config/testACL.yaml", config.Default())
+	require.NoError(t, err)
+
+	expect := config.Default()
+	expect.Security.ACL = []config.ACL{
+		{
+			Role:  "dba",
+			Admin: true,
+		},
+		{
+			Role: "eng",
+			Read: []string{"node", "host"},
+		},
+		{
+			Role:  "loader",
+			CDC:   true,
+			Read:  []string{"node", "host", "dns"},
+			Write: []string{"node", "host", "dns"},
+		},
+	}
+	assert.Equal(t, expect, got)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/square/etre
 
-go 1.22.0
-toolchain go1.23.2
+go 1.23.0
+
+toolchain go1.23.4
 
 require (
 	github.com/alexflint/go-arg v1.5.1

--- a/server/server.go
+++ b/server/server.go
@@ -246,6 +246,7 @@ func MapConfigACLRoles(aclRoles []config.ACL) ([]auth.ACL, error) {
 			Admin:             acl.Admin,
 			Read:              acl.Read,
 			Write:             acl.Write,
+			CDC:               acl.CDC,
 			TraceKeysRequired: acl.TraceKeysRequired,
 		}
 	}

--- a/test/config/testACL.yaml
+++ b/test/config/testACL.yaml
@@ -1,0 +1,18 @@
+security:
+  acl:
+    - role: dba
+      admin: true
+    - role: eng
+      read:
+        - node
+        - host
+    - role: loader
+      cdc: true
+      read:
+        - node
+        - host
+        - dns
+      write:
+        - node
+        - host
+        - dns


### PR DESCRIPTION
Previously we added a new field "ACL" to auth.ACL. It wasn't added in config.ACL so it was not being read from the configuration file. This change adds the new field to the config.ACL and adds tests to catch this in the future.