### PR TITLE
Add batch size to config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ const (
 	DEFAULT_QUERY_LATENCY_SLA              = "1s"
 	DEFAULT_QUERY_PROFILE_SAMPLE_RATE      = 0.2
 	DEFAULT_QUERY_PROFILE_REPORT_THRESHOLD = "500ms"
+	DEFAULT_BATCH_SIZE                     = 5000
 )
 
 const CDC_COLLECTION = "cdc"
@@ -37,7 +38,8 @@ var reservedNames = []string{"entity", "entities", "cdc", "etre"}
 func Default() Config {
 	return Config{
 		Entity: EntityConfig{
-			Types: []string{DEFAULT_ENTITY_TYPE},
+			Types:     []string{DEFAULT_ENTITY_TYPE},
+			BatchSize: DEFAULT_BATCH_SIZE,
 		},
 		Server: ServerConfig{
 			Addr: DEFAULT_ADDR,
@@ -192,7 +194,8 @@ func (c DatasourceConfig) WithDefaults(d DatasourceConfig) DatasourceConfig {
 }
 
 type EntityConfig struct {
-	Types []string `yaml:"types"`
+	Types     []string `yaml:"types"`
+	BatchSize int      `yaml:"batch_size"`
 }
 
 type CDCConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -68,6 +68,7 @@ func TestLoadTest001(t *testing.T) {
 	expect.Datasource.URL = "mongodb://10.0.0.2:4567"
 	expect.Datasource.Database = "test_db"
 	expect.Entity.Types = []string{"test"}
+	expect.Entity.BatchSize = 5000
 	expect.Metrics.QueryLatencySLA = "10ms"
 	assert.Equal(t, expect, got)
 }

--- a/entity/store_test.go
+++ b/entity/store_test.go
@@ -14,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/square/etre"
+	"github.com/square/etre/config"
 	"github.com/square/etre/entity"
 	"github.com/square/etre/query"
 	"github.com/square/etre/test"
@@ -73,7 +74,11 @@ func setup(t *testing.T, cdcm *mock.CDCStore) entity.Store {
 		testNodes[i]["_id"] = id.(primitive.ObjectID)
 	}
 
-	return entity.NewStore(coll, cdcm)
+	testConfig := config.EntityConfig{
+		Types:     []string{entityType},
+		BatchSize: 5000,
+	}
+	return entity.NewStore(coll, cdcm, testConfig)
 }
 
 func docs(entities []etre.Entity) []interface{} {

--- a/entity/v09_test.go
+++ b/entity/v09_test.go
@@ -14,6 +14,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/square/etre"
+	"github.com/square/etre/config"
 	"github.com/square/etre/entity"
 	"github.com/square/etre/query"
 	"github.com/square/etre/test"
@@ -68,7 +69,11 @@ func setupV09(t *testing.T, cdcm *mock.CDCStore) entity.Store {
 		v09testNodes_int32[i]["_id"] = id.(primitive.ObjectID)
 	}
 
-	return entity.NewStore(coll, cdcm)
+	testConfig := config.EntityConfig{
+		Types:     []string{entityType},
+		BatchSize: 5000,
+	}
+	return entity.NewStore(coll, cdcm, testConfig)
 }
 
 // --------------------------------------------------------------------------

--- a/server/server.go
+++ b/server/server.go
@@ -97,7 +97,7 @@ func (s *Server) Boot(configFile string) error {
 	for _, entityType := range cfg.Entity.Types {
 		coll[entityType] = mainClient.Database(cfg.Datasource.Database).Collection(entityType)
 	}
-	s.appCtx.EntityStore = entity.NewStore(coll, s.appCtx.CDCStore)
+	s.appCtx.EntityStore = entity.NewStore(coll, s.appCtx.CDCStore, cfg.Entity)
 	s.appCtx.EntityValidator = entity.NewValidator(cfg.Entity.Types)
 
 	// //////////////////////////////////////////////////////////////////////

--- a/test/config/test001.yaml
+++ b/test/config/test001.yaml
@@ -6,5 +6,6 @@ datasource:
 entity:
   types:
     - test
+  batch_size: 5000
 metrics:
   query_latency_sla: "10ms"


### PR DESCRIPTION
### Note
Add batch size to EntityConfig to reduce the number of underneath MongoDB `getMore` calls when querying etre entities.

### Testing
1. Started MongoDB in docker then run tests
```
cd test/docker
docker compose up
go test ./...
```
2. Tested via ods-etre https://github.com/squareup/ods-etre/compare/wenhui-batch-size/PLAT-20882 and deployed to ods-etre staging. Made call to etre staging `es --env staging dns type=cname-test` then check DD trace.
2.1 trace [link](https://square.datadoghq.com/apm/traces?query=env%3Astaging%20operation_name%3Anethttp.server%20service%3Aods-etre&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=span_list&historicalData=false&messageDisplay=inline&panel_tab=flamegraph&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=1696313319094832642&spanType=all&storage=hot&timeHint=1744689490300&trace=67fdd9510000000047d3ee38579f878d1696313319094832642&traceID=67fdd9510000000047d3ee38579f878d&view=spans&start=1744736610172&end=1744737510172&paused=false) before batch size change 
2.2 trace [link](https://square.datadoghq.com/apm/traces?query=env%3Astaging%20operation_name%3Anethttp.server%20service%3Aods-etre&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=span_list&historicalData=false&messageDisplay=inline&panel_tab=flamegraph&query_translation_version=v0&shouldShowLegend=true&sort=time&spanID=4063673543588839096&spanType=all&storage=hot&timeHint=1744696452543&trace=67fdf484000000005a2a9f2ebccc89234063673543588839096&traceID=67fdf484000000005a2a9f2ebccc8923&view=spans&start=1744736695455&end=1744737595455&paused=false) after batch size change 
which shows less number of calls to getMore with less execution time for the whole query.